### PR TITLE
Update README.md for use with Deno 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An implementation of the browser DOM—primarily for SSR—in Deno. Implemented 
 Rust, WASM, and obviously, Deno/TypeScript.
 
 ## Example
+
+*mod.ts*
 ```typescript
 import { DOMParser, Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-native.ts";
 
@@ -19,6 +21,28 @@ console.log(p.childNodes[1].textContent); // "Deno!"
 
 p.innerHTML = "DOM in <b>Deno</b> is pretty cool";
 console.log(p.children[0].outerHTML); // "<b>Deno</b>"
+```
+
+*minimum tsconfig.json*
+```json
+{
+  "compilerOptions": {
+    "importsNotUsedAsValues": "remove",
+    "isolatedModules": false
+  }
+}
+```
+
+To see your example in action, run:
+```sh
+deno run -c ./tsconfig.json -A --unstable ./mod.ts
+```
+
+You should see output like:
+```
+Hello from Deno!
+Deno!
+<html>DOM in <b>Deno</b> is pretty cool</html>
 ```
 
 Deno DOM has **two** backends, WASM and native using Deno native plugins. Both 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rust, WASM, and obviously, Deno/TypeScript.
 
 ## Example
 ```typescript
-import { DOMParser, Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha3/deno-dom-wasm.ts";
+import { DOMParser, Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-native.ts";
 
 const doc = new DOMParser().parseFromString(`
   <h1>Hello World!</h1>

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Rust, WASM, and obviously, Deno/TypeScript.
 
 ## Example
 
-*mod.ts*
 ```typescript
-import { DOMParser, Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-native.ts";
+import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-wasm.ts";
+import type { Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-wasm.ts";
 
 const doc = new DOMParser().parseFromString(`
   <h1>Hello World!</h1>
@@ -23,19 +23,9 @@ p.innerHTML = "DOM in <b>Deno</b> is pretty cool";
 console.log(p.children[0].outerHTML); // "<b>Deno</b>"
 ```
 
-*minimum tsconfig.json*
-```json
-{
-  "compilerOptions": {
-    "importsNotUsedAsValues": "remove",
-    "isolatedModules": false
-  }
-}
-```
-
-To see your example in action, run:
+To see this example in action, run:
 ```sh
-deno run -c ./tsconfig.json -A --unstable ./mod.ts
+deno run ./examples/basic/mod.ts
 ```
 
 You should see output like:

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,14 @@
+# basic example
+
+## how to run
+
+```sh
+$ deno run ./mod.ts
+```
+
+## should output
+```
+Hello from Deno!
+Deno!
+<html>DOM in <b>Deno</b> is pretty cool</html>
+```

--- a/examples/basic/mod.ts
+++ b/examples/basic/mod.ts
@@ -1,0 +1,15 @@
+import { DOMParser, Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-native.ts";
+
+const doc = new DOMParser().parseFromString(`
+  <h1>Hello World!</h1>
+  <p>Hello from <a href="https://deno.land/">Deno!</a></p>
+`, "text/html")!;
+
+const p = doc.querySelector("p")!;
+
+console.log(p.textContent); // "Hello from Deno!"
+console.log(p.childNodes[1].textContent); // "Deno!"
+
+p.innerHTML = "DOM in <b>Deno</b> is pretty cool";
+console.log(p.children[0].outerHTML); // "<b>Deno</b>"
+

--- a/examples/basic/mod.ts
+++ b/examples/basic/mod.ts
@@ -1,9 +1,10 @@
-import { DOMParser, Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-native.ts";
+import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-wasm.ts";
+import type { Element } from "https://deno.land/x/deno_dom@v0.1.2-alpha4/deno-dom-wasm.ts";
 
 const doc = new DOMParser().parseFromString(`
   <h1>Hello World!</h1>
   <p>Hello from <a href="https://deno.land/">Deno!</a></p>
-`, "text/html")!;
+`, "text/html")!; 
 
 const p = doc.querySelector("p")!;
 

--- a/examples/basic/run
+++ b/examples/basic/run
@@ -1,2 +1,0 @@
-#!/bin/sh
-deno run -c ./tsconfig.json -A --unstable ./mod.ts

--- a/examples/basic/run
+++ b/examples/basic/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+deno run -c ./tsconfig.json -A --unstable ./mod.ts

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "importsNotUsedAsValues": "remove",
+    "isolatedModules": false
+  }
+}

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
     "importsNotUsedAsValues": "remove",
-    "isolatedModules": false
   }
 }


### PR DESCRIPTION
# TL;DR
  - Added example
  - Updated README.md to work with Deno v1.4.0

I haven't done extensive testing with this yet, but firstly *thank you so much* for creating this. Saved me an hour of copying and pasting.

I was following the readme as it were, and `deno-dom-wasm.ts` failed repeatedly with a couple of errors. The first error I got was something about `importsNotUsedAsValues` being set to `"error"`:

![image](https://user-images.githubusercontent.com/16561284/93298004-6a742700-f7c0-11ea-97cb-61769b3051db.png)

Which I fixed by creating a `tsconfig.json` that looks like this:
```json
{
  "compilerOptions": {
    "importsNotUsedAsValues": "remove"
  }
}
```
After that was fixed, then I got this type error about `NodeType`:

![image](https://user-images.githubusercontent.com/16561284/93298124-aad3a500-f7c0-11ea-82d7-d98e489bcb1a.png)

Which I fixed by switching to `deno-dom-native`. But then I got an error about the `--isolatedModules` flag, which I solved by adding the following to the `tsconfig.json`:
## `tsconfig.json` changes
```json
{
  "compilerOptions": {
    "importsNotUsedAsValues": "remove",
    "isolatedModules": false
  }
}
```
## Error
![image](https://user-images.githubusercontent.com/16561284/93298240-e3737e80-f7c0-11ea-995a-8045b7db7f82.png)

I wasn't out of the woods yet though, as my good old friend `NodeType` error resurfaced. 
![image](https://user-images.githubusercontent.com/16561284/93298549-65fc3e00-f7c1-11ea-8df2-143e9d7aebf3.png)

I changed to the latest version - `v0.1.2-alpha4` - and presto, it worked!

Though it has this fun side-effect, that it creates a bunch of empty space in the terminal. But that didn't impact it from working! Thank you again for creating this! Keep up the good work!!!!

## The command used to run the script:
```sh
deno run -c ./tsconfig.json -A --unstable ./mod.ts
```
**Explaination**:
  - The `-c ./tsconfig.json` tells deno to run this script with the specified typescript compiler config
  - `-A`, short for `--allow-all`, gives the deno script to be run ***all permissions***, including: `--allow-env`, `--allow-net`, `--allow-plugin`, and in my case I also needed `--allow-read`, `--allow-write`.
  - `--unstable` enables the parts of the unstable deno API that are required for use.
  - And finally, `./mod.ts` would be the path to your deno script.