### PR TITLE
Fix outerHTML for void elements

### DIFF
--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -132,12 +132,7 @@ export class Element extends Node {
       case "source":
       case "track":
       case "wbr":
-        if (this.childNodes.length > 1) {
-          // What happened to the DOM lol
-          out += ">" + this.innerHTML + `</${ tagName }>`;
-        } else {
-          out += ">";
-        }
+        out += ">";
         break;
 
       default:

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -117,7 +117,7 @@ export class Element extends Node {
     }
 
     // Special handling for void elements
-    switch (this.tagName) {
+    switch (tagName) {
       case "area":
       case "base":
       case "br":

--- a/test/void-elements.ts
+++ b/test/void-elements.ts
@@ -1,0 +1,13 @@
+import { Document } from "../deno-dom-wasm.ts";
+
+const document = new Document().implementation.createHTMLDocument();
+const voidElement = document.createElement('br');
+
+console.log(`innerHTML: "${voidElement.innerHTML}" (should be empty)`);
+console.log(`outerHTML: "${voidElement.outerHTML}" (should be <br>)`);
+
+voidElement.appendChild(document.createElement('div'));
+console.log('childNodes.length: ', voidElement.childNodes.length);
+
+console.log(`innerHTML with child: "${voidElement.innerHTML}"`);
+console.log(`outerHTML with child: "${voidElement.outerHTML}"`);


### PR DESCRIPTION
We should be checking the lowercase `tagName` instead of the potentially uppercase `this.tagName`.