### PR TITLE
fix: stop arrays being counted as instances of subclasses of arrays

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,13 +13,13 @@ import { HTMLCollection } from "./dom/html-collection.ts";
 // Prevent childNodes and HTMLCollections from being seen as an arrays
 const oldHasInstance = Array[Symbol.hasInstance];
 Object.defineProperty(Array, Symbol.hasInstance, {
-  value: (value: any): boolean => {
+  value(value: any): boolean {
     switch (value?.constructor) {
       case HTMLCollection:
       case NodeList:
         return false;
       default:
-        return oldHasInstance.call(Array, value);
+        return oldHasInstance.call(this, value);
     }
   },
 });

--- a/test/instanceof.ts
+++ b/test/instanceof.ts
@@ -1,0 +1,34 @@
+import { DOMParser, NodeList, nodesFromString } from "../deno-dom-wasm.ts";
+import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Array instanceof Array", () => {
+  assert([] instanceof Array);
+  assert(Array.isArray([]));
+});
+
+Deno.test("NodeList not instanceof Array", () => {
+  const nodes = nodesFromString(
+    Deno.readTextFileSync(new URL("./basic.html", import.meta.url)),
+  );
+  assert(!(nodes instanceof Array));
+  assert(!Array.isArray(nodes));
+});
+
+Deno.test("HTMLCollection not instanceof Array", () => {
+  const nodes = nodesFromString(
+    Deno.readTextFileSync(new URL("./basic.html", import.meta.url)),
+  );
+  assert(!(nodes.children instanceof Array));
+  assert(!Array.isArray(nodes.children));
+});
+
+Deno.test("Subclass instanceof Array", () => {
+  class Foo extends Array {}
+  assert(new Foo() instanceof Array);
+  assert(Array.isArray(new Foo()));
+});
+
+Deno.test("Array not instanceof subclass", () => {
+  class Foo extends Array {}
+  assert(!([] instanceof Foo));
+});


### PR DESCRIPTION
The overriden `Array[Symbol.hasInstance]` is hardcoded to be called on `Array` (when it isn't being run on `HTMLCollection` or `NodeList`). Since subclasses of `Array` inherit this, it means that using `foo instanceof Subclass` will effectively act like `foo instanceof Array`. This fixes that by binding it to `this` instead of `Array`. 