### PR TITLE
Fix for #38: nwsapi.js global.DOMException is not a constructor

### DIFF
--- a/src/dom/nwsapi.js
+++ b/src/dom/nwsapi.js
@@ -17,7 +17,7 @@
  */
 
 export default document => {
-  const NW = Factory({ document }, "null");
+  const NW = Factory({ document, DOMException }, "null");
   NW.configure({
     IDS_DUPES: false,
     LOGERRORS: false,


### PR DESCRIPTION
I see that the function only uses 2 properties in global being `document` and `DOMException`. Since deno's runtime comes with DOMException, I thought just adding it to the factory would fix it. I tried it and it does work.

Please let me know if this change involves any other issues.