### PR TITLE
fix: node.ts: remove parentNode constructor assignment

### DIFF
--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -49,6 +49,7 @@ const nodesAndTextNodes = (nodes: (Node | any)[], parentNode: Node) => {
 export class Node extends EventTarget {
   public nodeValue: string | null;
   public childNodes: NodeList;
+  public parentNode: Node | null = null;
   public parentElement: Element | null;
   #childNodesMutator: NodeListMutator;
   #ownerDocument: Document | null = null;
@@ -72,7 +73,7 @@ export class Node extends EventTarget {
   constructor(
     public nodeName: string,
     public nodeType: NodeType,
-    public parentNode: Node | null,
+    parentNode: Node | null,
   ) {
     super();
     if (getLock()) {
@@ -129,7 +130,7 @@ export class Node extends EventTarget {
   _assertNotAncestor(child: Node) {
     // Check this child isn't an ancestor
     if (this._ancestors.has(child) || child === this) {
-      throw new Error("DOMException: The new child is an ancestor of the parent");
+      throw new DOMException("The new child is an ancestor of the parent");
     }
   }
 

--- a/test/units/Node-appendChild.ts
+++ b/test/units/Node-appendChild.ts
@@ -1,0 +1,40 @@
+import { DOMParser, Node } from "../../deno-dom-wasm.ts";
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Node.appendChild", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div class=parent></div>`,
+    "text/html",
+  )!;
+  const parent = doc.querySelector(".parent")!;
+  const child = doc.createElement("div");
+
+  parent.appendChild(child);
+
+  assertEquals(child.parentNode, parent, "parentNode has changed");
+  assertEquals(
+    parent.outerHTML,
+    `<div class="parent"><div></div></div>`,
+    "parent HTML reflects the new child",
+  );
+});
+
+Deno.test("Node.appendChild throws", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div class=parent><div class=child></div></div>`,
+    "text/html",
+  )!;
+  const parent = doc.querySelector(".parent")!;
+  const child = doc.querySelector(".child")!;
+
+  assertThrows(
+    () => {
+      child.appendChild(parent);
+    },
+    DOMException,
+    "The new child is an ancestor of the parent",
+  );
+});


### PR DESCRIPTION
Node constructor is calling "appendChild" on the parentNode, then calling "_setParent" on the child node.
But with parentNode property already set by constructor, "_setParent" is a noop.
The "_ancestors" property was not initialized properly.
Finally the _assertNotAncestor method could not do its job.

Added tests.