### PR TITLE
idea: constructor-lock.ts: use singleton instead of shared state

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,39 @@ export * from "./dom/element.ts";
 export * from "./dom/document.ts";
 export * from "./dom/dom-parser.ts";
 
+// Re-export private constructors without constructor signature
+import {
+  Node as ConstructibleNode,
+  CharacterData as ConstructibleCharacterData
+} from "./dom/node.ts"
+
+import {
+  Element as ConstructibleElement,
+  Attr as ConstructibleAttr
+} from "./dom/element.ts"
+
+export const Node: Pick<
+  typeof ConstructibleNode,
+  keyof typeof ConstructibleNode
+> = ConstructibleNode;
+export type Node = ConstructibleNode;
+
+export const CharacterData: Pick<
+  typeof ConstructibleCharacterData,
+  keyof typeof ConstructibleCharacterData
+> = ConstructibleCharacterData;
+export type CharacterData = ConstructibleCharacterData;
+
+export const Element: Pick<
+  typeof ConstructibleElement, keyof typeof ConstructibleElement
+> = ConstructibleElement;
+export type Element = ConstructibleElement;
+
+export const Attr: Pick<
+  typeof ConstructibleAttr, keyof typeof ConstructibleAttr
+> = ConstructibleAttr;
+export type Attr = ConstructibleAttr;
+
 export { NodeListPublic as NodeList } from "./dom/node-list.ts";
 export { HTMLCollectionPublic as HTMLCollection } from "./dom/html-collection.ts";
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,10 @@ import {
 } from "./dom/node.ts"
 
 import {
+  HTMLDocument as ConstructibleHTMLDocument,
+} from "./dom/document.ts"
+
+import {
   Element as ConstructibleElement,
   Attr as ConstructibleAttr
 } from "./dom/element.ts"
@@ -18,23 +22,29 @@ import {
 export const Node: Pick<
   typeof ConstructibleNode,
   keyof typeof ConstructibleNode
-> = ConstructibleNode;
+> & Function = ConstructibleNode;
 export type Node = ConstructibleNode;
+
+export const HTMLDocument: Pick<
+  typeof ConstructibleHTMLDocument,
+  keyof typeof ConstructibleHTMLDocument
+> & Function = ConstructibleHTMLDocument;
+export type HTMLDocument = ConstructibleHTMLDocument;
 
 export const CharacterData: Pick<
   typeof ConstructibleCharacterData,
   keyof typeof ConstructibleCharacterData
-> = ConstructibleCharacterData;
+> & Function = ConstructibleCharacterData;
 export type CharacterData = ConstructibleCharacterData;
 
 export const Element: Pick<
   typeof ConstructibleElement, keyof typeof ConstructibleElement
-> = ConstructibleElement;
+> & Function = ConstructibleElement;
 export type Element = ConstructibleElement;
 
 export const Attr: Pick<
   typeof ConstructibleAttr, keyof typeof ConstructibleAttr
-> = ConstructibleAttr;
+> & Function = ConstructibleAttr;
 export type Attr = ConstructibleAttr;
 
 export { NodeListPublic as NodeList } from "./dom/node-list.ts";

--- a/src/constructor-lock.ts
+++ b/src/constructor-lock.ts
@@ -1,13 +1,5 @@
 /**
  * Used to enforce illegal constructors
  */
-let lock = true;
 
-export function setLock(value: boolean) {
-  lock = value;
-}
-
-export function getLock(): boolean {
-  return lock;
-}
-
+export const CTOR_KEY = {};

--- a/src/constructor-lock.ts
+++ b/src/constructor-lock.ts
@@ -2,4 +2,4 @@
  * Used to enforce illegal constructors
  */
 
-export const CTOR_KEY = {};
+export const CTOR_KEY = Symbol();

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,23 +1,19 @@
 import { parse, parseFrag } from "./parser.ts";
-import { setLock } from "./constructor-lock.ts";
+import { CTOR_KEY } from "./constructor-lock.ts";
 import { Node, NodeType, Text, Comment } from "./dom/node.ts";
 import { DocumentType } from "./dom/document.ts";
 import { Element } from "./dom/element.ts";
 
 export function nodesFromString(html: string): Node {
-  setLock(false);
   const parsed = JSON.parse(parse(html));
   const node = nodeFromArray(parsed, null);
-  setLock(true);
 
   return node;
 }
 
 export function fragmentNodesFromString(html: string): Node {
-  setLock(false);
   const parsed = JSON.parse(parseFrag(html));
   const node = nodeFromArray(parsed, null);
-  setLock(true);
 
   return node;
 }
@@ -26,7 +22,7 @@ function nodeFromArray(data: any, parentNode: Node | null): Node {
   // For reference only:
   // type node = [NodeType, nodeName, attributes, node[]]
   //             | [NodeType, characterData]
-  const elm = new Element(data[1], parentNode, data[2]);
+  const elm = new Element(data[1], parentNode, data[2], CTOR_KEY);
   const childNodes = elm._getChildNodesMutator();
   let childNode: Node;
 
@@ -50,7 +46,7 @@ function nodeFromArray(data: any, parentNode: Node | null): Node {
         break;
 
       case NodeType.DOCUMENT_TYPE_NODE:
-        childNode = new DocumentType(child[1], child[2], child[3]);
+        childNode = new DocumentType(child[1], child[2], child[3], CTOR_KEY);
         childNode.parentNode = childNode.parentElement = <Element>elm;
         childNodes.push(childNode);
         break;

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -5,7 +5,7 @@ import { Element } from "./element.ts";
 import { DOM as NWAPI } from "./nwsapi-types.ts";
 
 export class DOMImplementation {
-  constructor(key: any) {
+  constructor(key: symbol) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor.");
     }
@@ -55,7 +55,7 @@ export class DocumentType extends Node {
     name: string,
     publicId: string,
     systemId: string,
-    key: any,
+    key: symbol,
   ) {
     super(
       "html", 
@@ -291,7 +291,7 @@ export class Document extends Node {
 }
 
 export class HTMLDocument extends Document {
-  constructor(key: any) {
+  constructor(key: symbol) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor.");
     }

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -5,7 +5,7 @@ import { Element } from "./element.ts";
 import { DOM as NWAPI } from "./nwsapi-types.ts";
 
 export class DOMImplementation {
-  constructor(key: symbol) {
+  constructor(key: typeof CTOR_KEY) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor.");
     }
@@ -55,7 +55,7 @@ export class DocumentType extends Node {
     name: string,
     publicId: string,
     systemId: string,
-    key: symbol,
+    key: typeof CTOR_KEY,
   ) {
     super(
       "html", 
@@ -291,7 +291,7 @@ export class Document extends Node {
 }
 
 export class HTMLDocument extends Document {
-  constructor(key: symbol) {
+  constructor(key: typeof CTOR_KEY) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor.");
     }

--- a/src/dom/dom-parser.ts
+++ b/src/dom/dom-parser.ts
@@ -1,4 +1,4 @@
-import { getLock, setLock } from "../constructor-lock.ts";
+import { CTOR_KEY } from "../constructor-lock.ts";
 import { nodesFromString } from "../deserialize.ts";
 import { HTMLDocument, DocumentType } from "./document.ts";
 import type { Element } from "./element.ts";
@@ -16,10 +16,7 @@ export class DOMParser {
       throw new Error(`DOMParser: "${ mimeType }" unimplemented`); // TODO
     }
 
-    setLock(false);
-    const doc = new HTMLDocument();
-
-    setLock(false);
+    const doc = new HTMLDocument(CTOR_KEY);
 
     const fakeDoc = nodesFromString(source);
     let htmlNode: Element | null = null;
@@ -36,8 +33,7 @@ export class DOMParser {
     }
 
     if (!hasDoctype) {
-      setLock(false);
-      const docType = new DocumentType("html", "", "");
+      const docType = new DocumentType("html", "", "", CTOR_KEY);
       // doc.insertBefore(docType, doc.firstChild);
       if (doc.childNodes.length === 0) {
         doc.appendChild(docType);
@@ -45,8 +41,6 @@ export class DOMParser {
         doc.childNodes[0].before(docType);
       }
     }
-
-    setLock(true);
 
     if (htmlNode) {
       for (const child of htmlNode.childNodes) {

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -64,7 +64,7 @@ export class Attr {
   #namedNodeMap: NamedNodeMap | null = null;
   #name: string = "";
 
-  constructor(map: NamedNodeMap, name: string, key: any) {
+  constructor(map: NamedNodeMap, name: string, key: symbol) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor");
     }
@@ -114,7 +114,7 @@ export class Element extends Node {
     public tagName: string,
     parentNode: Node | null,
     attributes: [string, string][],
-    key: any,
+    key: symbol,
   ) {
     super(
       tagName,

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -1,4 +1,4 @@
-import { getLock } from "../constructor-lock.ts";
+import { CTOR_KEY } from "../constructor-lock.ts";
 import { fragmentNodesFromString } from "../deserialize.ts";
 import { Node, NodeType, Text, Comment } from "./node.ts";
 import { NodeList, nodeListMutatorSym } from "./node-list.ts";
@@ -60,13 +60,12 @@ export class DOMTokenList extends Set<string> {
   }
 }
 
-let attrLock = true;
 export class Attr {
   #namedNodeMap: NamedNodeMap | null = null;
   #name: string = "";
 
-  constructor(map: NamedNodeMap, name: string) {
-    if (attrLock) {
+  constructor(map: NamedNodeMap, name: string, key: any) {
+    if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor");
     }
 
@@ -89,10 +88,7 @@ export class NamedNodeMap {
   } = {};
 
   private newAttr(attribute: string): Attr {
-    attrLock = false;
-    const attr = new Attr(this, attribute);
-    attrLock = true;
-    return attr;
+    return new Attr(this, attribute, CTOR_KEY);
   }
 
   getNamedItem(attribute: string) {
@@ -118,15 +114,14 @@ export class Element extends Node {
     public tagName: string,
     parentNode: Node | null,
     attributes: [string, string][],
+    key: any,
   ) {
     super(
       tagName,
       NodeType.ELEMENT_NODE,
       parentNode,
+      key,
     );
-    if (getLock()) {
-      throw new TypeError("Illegal constructor");
-    }
 
     for (const attr of attributes) {
       this.attributes[attr[0]] = attr[1];

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -64,7 +64,7 @@ export class Attr {
   #namedNodeMap: NamedNodeMap | null = null;
   #name: string = "";
 
-  constructor(map: NamedNodeMap, name: string, key: symbol) {
+  constructor(map: NamedNodeMap, name: string, key: typeof CTOR_KEY) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor");
     }
@@ -114,7 +114,7 @@ export class Element extends Node {
     public tagName: string,
     parentNode: Node | null,
     attributes: [string, string][],
-    key: symbol,
+    key: typeof CTOR_KEY,
   ) {
     super(
       tagName,

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -74,7 +74,7 @@ export class Node extends EventTarget {
     public nodeName: string,
     public nodeType: NodeType,
     parentNode: Node | null,
-    key: symbol,
+    key: typeof CTOR_KEY,
   ) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor.");
@@ -478,7 +478,7 @@ export class CharacterData extends Node {
     nodeName: string,
     nodeType: NodeType,
     parentNode: Node | null,
-    key: symbol,
+    key: typeof CTOR_KEY,
   ) {
     super(
       nodeName,

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -1,4 +1,4 @@
-import { getLock, setLock } from "../constructor-lock.ts";
+import { CTOR_KEY } from "../constructor-lock.ts";
 import { NodeList, NodeListMutator, nodeListMutatorSym } from "./node-list.ts";
 import { HTMLCollection, HTMLCollectionMutator, HTMLCollectionMutatorSym } from "./html-collection.ts";
 import type { Element } from "./element.ts";
@@ -74,11 +74,12 @@ export class Node extends EventTarget {
     public nodeName: string,
     public nodeType: NodeType,
     parentNode: Node | null,
+    key: any,
   ) {
-    super();
-    if (getLock()) {
-      throw new TypeError("Illegal constructor");
+    if (key !== CTOR_KEY) {
+      throw new TypeError("Illegal constructor.");
     }
+    super();
 
     this.nodeValue = null;
     this.childNodes = new NodeList();
@@ -477,15 +478,14 @@ export class CharacterData extends Node {
     nodeName: string,
     nodeType: NodeType,
     parentNode: Node | null,
+    key: any,
   ) {
     super(
       nodeName,
       nodeType,
       parentNode,
+      key,
     );
-    if (getLock()) {
-      throw new TypeError("Illegal constructor");
-    }
 
     this.nodeValue = data;
   }
@@ -502,17 +502,15 @@ export class Text extends CharacterData {
   constructor(
     text: string = "",
   ) {
-    let oldLock = getLock();
-    setLock(false);
     super(
       text,
       "#text",
       NodeType.TEXT_NODE,
       null,
+      CTOR_KEY,
     );
 
     this.nodeValue = text;
-    setLock(oldLock);
   }
 
   get textContent(): string {
@@ -524,17 +522,15 @@ export class Comment extends CharacterData {
   constructor(
     text: string = "",
   ) {
-    let oldLock = getLock();
-    setLock(false);
     super(
       text,
       "#comment",
       NodeType.COMMENT_NODE,
       null,
+      CTOR_KEY,
     );
 
     this.nodeValue = text;
-    setLock(oldLock);
   }
 
   get textContent(): string {

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -74,7 +74,7 @@ export class Node extends EventTarget {
     public nodeName: string,
     public nodeType: NodeType,
     parentNode: Node | null,
-    key: any,
+    key: symbol,
   ) {
     if (key !== CTOR_KEY) {
       throw new TypeError("Illegal constructor.");
@@ -478,7 +478,7 @@ export class CharacterData extends Node {
     nodeName: string,
     nodeType: NodeType,
     parentNode: Node | null,
-    key: any,
+    key: symbol,
   ) {
     super(
       nodeName,

--- a/test/units/throws-dom-exception.ts
+++ b/test/units/throws-dom-exception.ts
@@ -13,14 +13,14 @@ Deno.test("Invalid querySelector query throws DOMException", () => {
 Deno.test("Throws on invalid constructor key", () => {
   assertThrows(
     () => {
-      new HTMLDocument(undefined as any);
+      new (HTMLDocument as any)(undefined);
     },
     TypeError,
     "Illegal constructor.",
   );
   assertThrows(
     () => {
-      new HTMLDocument({});
+      new (HTMLDocument as any)({});
     },
     TypeError,
     "Illegal constructor.",

--- a/test/units/throws-dom-exception.ts
+++ b/test/units/throws-dom-exception.ts
@@ -1,5 +1,5 @@
-import { DOMParser, NodeList } from "../../deno-dom-wasm.ts";
-import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+import { HTMLDocument, DOMParser, NodeList } from "../../deno-dom-wasm.ts";
+import { assert, assertThrows } from "https://deno.land/std@0.85.0/testing/asserts.ts";
 
 Deno.test("Invalid querySelector query throws DOMException", () => {
   const doc = new DOMParser().parseFromString("<div></div>", "text/html")!;
@@ -10,3 +10,19 @@ Deno.test("Invalid querySelector query throws DOMException", () => {
   }
 });
 
+Deno.test("Throws on invalid constructor key", () => {
+  assertThrows(
+    () => {
+      new HTMLDocument(undefined as any);
+    },
+    TypeError,
+    "Illegal constructor.",
+  );
+  assertThrows(
+    () => {
+      new HTMLDocument({});
+    },
+    TypeError,
+    "Illegal constructor.",
+  );
+});


### PR DESCRIPTION
I find the getLock/setLock principle difficult to predict when used recursively; and a bit verbose.
I suggest the use of a singleton (CTOR_KEY), that must be passed as last argument of all illegal constructors.