### PR TITLE
node.ts: implement Node.childElementCount

### DIFF
--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -321,6 +321,14 @@ export class Node extends EventTarget {
     }
   }
 
+  get childElementCount(): number {
+    let count = 0;
+    for (const { nodeType } of this.childNodes) {
+      count += +(nodeType === NodeType.ELEMENT_NODE);
+    }
+    return count;
+  }
+
   get children(): HTMLCollection {
     const collection = new HTMLCollection();
     const mutator = collection[HTMLCollectionMutatorSym]();

--- a/test/units/Node-childElementCount.ts
+++ b/test/units/Node-childElementCount.ts
@@ -1,0 +1,33 @@
+import { Document } from "../../deno-dom-wasm.ts";
+import { assertEquals } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Document.childElementCount", () => {
+  const document = new Document();
+  assertEquals(document.childElementCount, 0);
+});
+
+Deno.test("Element.childElementCount", () => {
+  const document = new Document();
+  const list = document.createElement("ul");
+  for (let i = 0; i < 3; i++) {
+    list.appendChild(document.createElement("li"));
+  }
+  assertEquals(list.childElementCount, 3);
+});
+
+Deno.test("Element.childElementCount", () => {
+  const document = new Document();
+  const list = document.createElement("ul");
+  for (let i = 0; i < 3; i++) {
+    list.appendChild(document.createElement("li"));
+  }
+  assertEquals(list.childElementCount, 3);
+});
+
+Deno.test("Element.childElementCount with non-node", () => {
+  const document = new Document();
+  const divider = document.createElement("div");
+  divider.appendChild(document.createElement("p"));
+  divider.appendChild(document);
+  assertEquals(divider.childElementCount, 1);
+});


### PR DESCRIPTION
Implement Node.childElementCount.

The Document.childElementCount read-only property returns the number of child elements of the document.

https://developer.mozilla.org/en-US/docs/Web/API/Element/childElementCount
https://developer.mozilla.org/en-US/docs/Web/API/Document/childElementCount