### PR TITLE
feat(node): add events support

### DIFF
--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -3,20 +3,6 @@ import { NodeList, NodeListMutator, nodeListMutatorSym } from "./node-list.ts";
 import type { Element } from "./element.ts";
 import type { Document } from "./document.ts";
 
-export class EventTarget {
-  addEventListener() {
-    // TODO
-  }
-
-  removeEventListener() {
-    // TODO
-  }
-
-  dispatchEvent() {
-    // TODO
-  }
-}
-
 export enum NodeType {
   ELEMENT_NODE = 1,
   ATTRIBUTE_NODE = 2,
@@ -442,6 +428,16 @@ export class Node extends EventTarget {
     // point should be unreachable code as per the
     // intended logic
     return Node.DOCUMENT_POSITION_FOLLOWING;
+  }
+
+  getRootNode(opts: { composed?: boolean } = {}): Node {
+    if (this.parentNode) {
+      return this.parentNode.getRootNode(opts);
+    }
+    if (opts.composed && (this as any).host) {
+      (this as any).host.getRootNode(opts);
+    }
+    return this;
   }
 }
 

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -435,7 +435,7 @@ export class Node extends EventTarget {
       return this.parentNode.getRootNode(opts);
     }
     if (opts.composed && (this as any).host) {
-      (this as any).host.getRootNode(opts);
+      return (this as any).host.getRootNode(opts);
     }
     return this;
   }

--- a/test/units/Node-events.ts
+++ b/test/units/Node-events.ts
@@ -1,0 +1,56 @@
+import { DOMParser } from "../../deno-dom-wasm.ts";
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Node.dispatchEvent", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div></div>`,
+    "text/html",
+  )!;
+  const div = doc.querySelector("div")!;
+  let called = false;
+  div.addEventListener("click", () => {
+    called = true;
+  });
+  div.dispatchEvent(new Event("click"));
+  assert(called);
+});
+
+Deno.test("Node.dispatchEvent, event bubbles", async () => {
+  const doc = new DOMParser().parseFromString(
+    `<div class="parent"><div class="child"></div></div>`,
+    "text/html",
+  )!;
+  const parent = doc.querySelector(".parent")!;
+  const child = doc.querySelector(".child")!;
+  let called = false;
+  // FIXME(kt3k): this empty event handler is necessary to work around
+  // the bug in EventTarget impl in Deno.
+  child.addEventListener("click", () => {});
+  parent.addEventListener("click", () => {
+    called = true;
+  });
+  child.dispatchEvent(new Event("click", { bubbles: true }));
+  await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  assertEquals(called, true);
+});
+
+Deno.test("Node.removeEventListener removes the event listener", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div></div>`,
+    "text/html",
+  )!;
+  const div = doc.querySelector("div")!;
+  let callCount = 0;
+  const handler = () => {
+    callCount++;
+  };
+  div.addEventListener("click", handler);
+  div.dispatchEvent(new Event("click"));
+  assertEquals(callCount, 1);
+  div.removeEventListener("click", handler);
+  div.dispatchEvent(new Event("click"));
+  assertEquals(callCount, 1);
+});


### PR DESCRIPTION
This PR implements DOM Event handlings using Deno's EventTarget implementation.