### PR TITLE
fix(DOMTokenList): fix add method

### DIFF
--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -12,7 +12,14 @@ export class DOMTokenList extends Set<string> {
     this.#onChange = onChange;
   }
 
-  add(token: string): this {
+  add(...tokens: string[]): this {
+    for (const token of tokens) {
+      this.#addOne(token);
+    }
+    return this;
+  }
+
+  #addOne(token: string): this {
     if (token === "" || /[\t\n\f\r ]/.test(token)) {
       throw new Error(`DOMTokenList.add: Invalid class token "${token}"`);
     }

--- a/test/units/Element-classList.ts
+++ b/test/units/Element-classList.ts
@@ -1,0 +1,12 @@
+import { DOMParser } from "../../deno-dom-wasm.ts";
+import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Element.classList.add", () => {
+  const doc = new DOMParser().parseFromString("<div></div>", "text/html")!;
+  const div = doc.querySelector("div")!;
+  div.classList.add("a");
+  div.classList.add("b", "c");
+  assert(div.classList.has("a"));
+  assert(div.classList.has("b"));
+  assert(div.classList.has("c"));
+});


### PR DESCRIPTION
`element.classList.add()` method accepts arbitrary number of arguments. ref: https://github.com/web-platform-tests/wpt/blob/d8a55060299a921567c4ac179e3702fa5d53feb9/dom/nodes/Element-classlist.html#L274-L279

The current implementation only accepts one argument for each call. This PR fixes it.