### PR TITLE
fix getElementsByClassName

### DIFF
--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -307,9 +307,11 @@ export class Document extends Node {
   private _getElementsByClassName(className: string, search: Node[]): Node[] {
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
-        if ((<Element> child).classList.contains(className)) {
-          search.push(child);
-        }
+        className.split(" ").forEach((singleClassName) => {
+          if ((<Element> child).classList.contains(singleClassName)) {
+            search.push(child);
+          }
+        });
 
         (<any> child)._getElementsByClassName(className, search);
       }

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -3,6 +3,7 @@ import { Node, NodeType, Text, Comment } from "./node.ts";
 import { NodeList, nodeListMutatorSym } from "./node-list.ts";
 import { Element } from "./element.ts";
 import { DOM as NWAPI } from "./nwsapi-types.ts";
+import { getElementsByClassName } from "./utils.ts";
 
 export class DOMImplementation {
   constructor(key: typeof CTOR_KEY) {
@@ -301,38 +302,7 @@ export class Document extends Node {
   }
 
   getElementsByClassName(className: string): Element[] {
-    return <Element[]> this._getElementsByClassName(className, []);
-  }
-
-  private _getElementsByClassName(className: string, search: Node[]): Node[] {
-    for (const child of this.childNodes) {
-      if (child.nodeType === NodeType.ELEMENT_NODE) {
-        // remove duplicate class names
-        const classList = new Set(className.split(" "));
-
-        let matches: Node[] = [];
-        let matchesCount = 0;
-
-        for (const singleClassName of classList) {
-          if ((<Element> child).classList.contains(singleClassName)) {
-            matchesCount++;
-            // avoid pushing the same element multiple times due to multiple class names
-            if (!matches.includes(child)) {
-              matches.push(child);
-            }
-          }
-        }
-
-        // ensure that all class names are present
-        if (matchesCount >= classList.size) {
-          search.push(...matches);
-        }
-
-        (<any> child)._getElementsByClassName(className, search);
-      }
-    }
-
-    return search;
+    return <Element[]> getElementsByClassName(this, className, []);
   }
 
   hasFocus(): boolean {
@@ -352,4 +322,3 @@ export class HTMLDocument extends Document {
     return new HTMLDocument(CTOR_KEY);
   }
 }
-

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -307,11 +307,26 @@ export class Document extends Node {
   private _getElementsByClassName(className: string, search: Node[]): Node[] {
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
-        className.split(" ").forEach((singleClassName) => {
+        // remove duplicate class names
+        const classList = new Set(className.split(" "));
+
+        let matches: Node[] = [];
+        let matchesCount = 0;
+
+        for (const singleClassName of classList) {
           if ((<Element> child).classList.contains(singleClassName)) {
-            search.push(child);
+            matchesCount++;
+            // avoid pushing the same element multiple times due to multiple class names
+            if (!matches.includes(child)) {
+              matches.push(child);
+            }
           }
-        });
+        }
+
+        // ensure that all class names are present
+        if (matchesCount >= classList.size) {
+          search.push(...matches);
+        }
 
         (<any> child)._getElementsByClassName(className, search);
       }

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -2,7 +2,8 @@ import { CTOR_KEY } from "../constructor-lock.ts";
 import { fragmentNodesFromString } from "../deserialize.ts";
 import { Node, NodeType, Text, Comment, nodesAndTextNodes } from "./node.ts";
 import { NodeList, nodeListMutatorSym } from "./node-list.ts";
-import { HTMLCollection, HTMLCollectionMutator, HTMLCollectionMutatorSym } from "./html-collection.ts";
+import { HTMLCollection } from "./html-collection.ts";
+import { getElementsByClassName } from "./utils.ts";
 
 export class DOMTokenList extends Set<string> {
   #onChange: (className: string) => void;
@@ -485,43 +486,11 @@ export class Element extends Node {
   }
 
   getElementsByClassName(className: string): Element[] {
-    return <Element[]> this._getElementsByClassName(className, []);
+    return <Element[]> getElementsByClassName(this, className, []);
   }
 
   getElementsByTagNameNS(_namespace: string, localName: string): Element[] {
     // TODO: Use namespace
     return this.getElementsByTagName(localName);
   }
-
-  private _getElementsByClassName(className: string, search: Node[]): Node[] {
-    for (const child of this.childNodes) {
-      if (child.nodeType === NodeType.ELEMENT_NODE) {
-        // remove duplicate class names
-        const classList = new Set(className.split(" "));
-
-        let matches: Node[] = [];
-        let matchesCount = 0;
-
-        for (const singleClassName of classList) {
-          if ((<Element> child).classList.contains(singleClassName)) {
-            matchesCount++;
-            // avoid pushing the same element multiple times due to multiple class names
-            if (!matches.includes(child)) {
-              matches.push(child);
-            }
-          }
-        }
-
-        // ensure that all class names are present
-        if (matchesCount >= classList.size) {
-          search.push(...matches);
-        }
-
-        (<Element> child)._getElementsByClassName(className, search);
-      }
-    }
-
-    return search;
-  }
 }
-

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -496,9 +496,11 @@ export class Element extends Node {
   private _getElementsByClassName(className: string, search: Node[]): Node[] {
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
-        if ((<Element> child).classList.contains(className)) {
-          search.push(child);
-        }
+        className.split(" ").forEach((singleClassName) => {
+          if ((<Element> child).classList.contains(singleClassName)) {
+            search.push(child);
+          }
+        });
 
         (<Element> child)._getElementsByClassName(className, search);
       }

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -496,11 +496,26 @@ export class Element extends Node {
   private _getElementsByClassName(className: string, search: Node[]): Node[] {
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
-        className.split(" ").forEach((singleClassName) => {
+        // remove duplicate class names
+        const classList = new Set(className.split(" "));
+
+        let matches: Node[] = [];
+        let matchesCount = 0;
+
+        for (const singleClassName of classList) {
           if ((<Element> child).classList.contains(singleClassName)) {
-            search.push(child);
+            matchesCount++;
+            // avoid pushing the same element multiple times due to multiple class names
+            if (!matches.includes(child)) {
+              matches.push(child);
+            }
           }
-        });
+        }
+
+        // ensure that all class names are present
+        if (matchesCount >= classList.size) {
+          search.push(...matches);
+        }
 
         (<Element> child)._getElementsByClassName(className, search);
       }

--- a/src/dom/utils.ts
+++ b/src/dom/utils.ts
@@ -1,0 +1,30 @@
+import { Node, NodeType } from "./node.ts";
+import { Element } from "./element.ts";
+
+export function getElementsByClassName(
+  element: any,
+  className: string,
+  search: Node[],
+): Node[] {
+  for (const child of element.childNodes) {
+    if (child.nodeType === NodeType.ELEMENT_NODE) {
+      const classList = className.trim().split(/\s+/);
+      let matchesCount = 0;
+
+      for (const singleClassName of classList) {
+        if ((<Element> child).classList.contains(singleClassName)) {
+          matchesCount++;
+        }
+      }
+
+      // ensure that all class names are present
+      if (matchesCount === classList.length) {
+        search.push(child);
+      }
+
+      getElementsByClassName(<Element> child, className, search);
+    }
+  }
+
+  return search;
+}

--- a/test/units/Element-getElementsBy.ts
+++ b/test/units/Element-getElementsBy.ts
@@ -52,6 +52,7 @@ Deno.test("Element.getElementsByClassName", () => {
           <article class=an-article>
             <p class=this-p>Foo bar baz</p>
           </article>
+					<p class="a b c">working</p>
         </aside>
       </div>
     `,
@@ -82,6 +83,14 @@ Deno.test("Element.getElementsByClassName", () => {
   assertEquals(mainP, articleP);
   assertEquals(mainP.parentNode, article);
   assertEquals(imgParentArticle, article);
+
+  assertEquals(doc.getElementsByClassName("a c").length, 1);
+  assertEquals(doc.getElementsByClassName("  a   b   ").length, 1);
+  assertEquals(doc.getElementsByClassName("  a  dd b   ").length, 0);
+  assertEquals(doc.getElementsByClassName("  a  c b   ").length, 1);
+  assertEquals(doc.getElementsByClassName("c").length, 1);
+  assertEquals(doc.getElementsByClassName("v").length, 0);
+  assertEquals(doc.getElementsByClassName("a a b c b").length, 1);
 });
 
 Deno.test("Element.getElementById", () => {
@@ -125,4 +134,3 @@ Deno.test("Element.getElementById", () => {
   assertEquals(mainP.parentNode, article);
   assertEquals(imgParentArticle, article);
 });
-

--- a/test/units/Element-getElementsBy.ts
+++ b/test/units/Element-getElementsBy.ts
@@ -52,7 +52,7 @@ Deno.test("Element.getElementsByClassName", () => {
           <article class=an-article>
             <p class=this-p>Foo bar baz</p>
           </article>
-					<p class="a b c">working</p>
+          <p class="a b c">working</p>
         </aside>
       </div>
     `,


### PR DESCRIPTION
Fixed `getElementsByClassName` with multiple classes separated by a space character as argument
```ts
import {DOMParser} from "../deno-dom/deno-dom-wasm.ts"

const doc = new DOMParser().parseFromString('<p class="a b c"></p>', 'text/html')!
console.log(doc.getElementsByClassName('a b')[0]!)
```
Before only this worked
```ts
console.log(doc.getElementsByClassName('a')[0]!)
```
But as described [here](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName#examples), the first example should work too.
