### PR TITLE
fix: Fix test failures and update test documentation

### DIFF
--- a/.github/workflows/deno-dom.yml
+++ b/.github/workflows/deno-dom.yml
@@ -29,4 +29,4 @@ jobs:
         run: deno fmt --check --unstable
 
       - name: Run tests
-        run: deno test -A --unstable --ignore=native.test.ts
+        run: deno test --allow-read --allow-net wasm.test.ts

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ inconsistencies (that aren't a result of legacy APIs) file an issue.
 To run tests (excluding WPT tests) use the following for WASM
 
 ```sh
-deno test --allow-read wasm.test.ts
+deno test --allow-read --allow-net wasm.test.ts
 ```
 
 Or the following for native (native requires more permissions)
@@ -111,7 +111,7 @@ git submodule update --progress --depth 1
 Then append `-- --wpt` to the test command before running it, e.g. for WASM
 
 ```sh
-deno test --allow-read wasm.test.ts -- --wpt
+deno test --allow-read --allow-net wasm.test.ts -- --wpt
 ```
 
 WPT tests are still a WIP, passed tests likely haven't actually passed.

--- a/test/units/comments-outside-html-test.ts
+++ b/test/units/comments-outside-html-test.ts
@@ -5,6 +5,7 @@ import {
   DocumentType,
   DOMParser,
   Element,
+  Node,
 } from "../../deno-dom-wasm.ts";
 
 Deno.test("Comment before <html>", async () => {
@@ -25,7 +26,7 @@ Deno.test("Comment before <html>", async () => {
     " TODO: Bells and whistles ",
   );
   assert(document.childNodes[3] instanceof Element);
-  assertEquals(document.documentElement, document.childNodes[3]);
+  assertEquals(document.documentElement as Node | null, document.childNodes[3]);
   assert(document.childNodes[4] instanceof Comment);
   assertEquals(
     (document.childNodes[4] as Comment).data,


### PR DESCRIPTION
This PR:

- fixes a typecheck failure in `test/units/comments-outside-html-test.ts`;
- updates the readme to add the `--allow-net` flag to the `wasm.test.ts` test command, since that is needed to do dynamic import of all unit tests;
- updates the CI workflow to use the same command as the readme, since the previous command seemed to also run some (but not all) WPT tests as if they were Deno test files.
