### PR TITLE
fix: `ChildNode` insert/replace methods don't work well with siblings

### DIFF
--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -707,13 +707,13 @@ export class Element extends Node {
 
   before(...nodes: (Node | string)[]) {
     if (this.parentNode) {
-      insertBeforeAfter(this, nodes, 0);
+      insertBeforeAfter(this, nodes, true);
     }
   }
 
   after(...nodes: (Node | string)[]) {
     if (this.parentNode) {
-      insertBeforeAfter(this, nodes, 1);
+      insertBeforeAfter(this, nodes, false);
     }
   }
 

--- a/src/dom/node-list.ts
+++ b/src/dom/node-list.ts
@@ -212,6 +212,7 @@ export interface NodeListPublic extends NodeList {
 }
 
 export interface NodeListMutator {
+  arrayInstance: Node[];
   push(...nodes: Node[]): number;
   splice(start: number, deleteCount?: number, ...items: Node[]): Node[];
   indexOf(node: Node, fromIndex?: number | undefined): number;

--- a/src/dom/node-list.ts
+++ b/src/dom/node-list.ts
@@ -212,7 +212,6 @@ export interface NodeListPublic extends NodeList {
 }
 
 export interface NodeListMutator {
-  arrayInstance: Node[];
   push(...nodes: Node[]): number;
   splice(start: number, deleteCount?: number, ...items: Node[]): Node[];
   indexOf(node: Node, fromIndex?: number | undefined): number;

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -340,10 +340,29 @@ export class Node extends EventTarget {
     if (this.parentNode) {
       const parentNode = this.parentNode;
       const mutator = parentNode._getChildNodesMutator();
-      const index = mutator.indexOf(this);
+      let viableNextSibling: Node | null = null;
+      {
+        const thisIndex = mutator.indexOf(this);
+        for (let i = thisIndex + 1; i < mutator.arrayInstance.length; i++) {
+          if (!nodes.includes(mutator.arrayInstance[i])) {
+            viableNextSibling = mutator.arrayInstance[i];
+            break;
+          }
+        }
+      }
       nodes = nodesAndTextNodes(nodes, parentNode);
 
-      mutator.splice(index, 1, ...(nodes as Node[]));
+      let index = viableNextSibling
+        ? mutator.indexOf(viableNextSibling)
+        : mutator.arrayInstance.length;
+      let deleteNumber;
+      if (mutator.arrayInstance[index - 1] === this) {
+        index--;
+        deleteNumber = 1;
+      } else {
+        deleteNumber = 0;
+      }
+      mutator.splice(index, deleteNumber, ...(nodes as Node[]));
       this._setParent(null);
     }
   }
@@ -574,13 +593,13 @@ export class CharacterData extends Node {
 
   before(...nodes: (Node | string)[]) {
     if (this.parentNode) {
-      insertBeforeAfter(this, nodes, 0);
+      insertBeforeAfter(this, nodes, true);
     }
   }
 
   after(...nodes: (Node | string)[]) {
     if (this.parentNode) {
-      insertBeforeAfter(this, nodes, 1);
+      insertBeforeAfter(this, nodes, false);
     }
   }
 

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -343,9 +343,9 @@ export class Node extends EventTarget {
       let viableNextSibling: Node | null = null;
       {
         const thisIndex = mutator.indexOf(this);
-        for (let i = thisIndex + 1; i < mutator.arrayInstance.length; i++) {
-          if (!nodes.includes(mutator.arrayInstance[i])) {
-            viableNextSibling = mutator.arrayInstance[i];
+        for (let i = thisIndex + 1; i < parentNode.childNodes.length; i++) {
+          if (!nodes.includes(parentNode.childNodes[i])) {
+            viableNextSibling = parentNode.childNodes[i];
             break;
           }
         }
@@ -354,9 +354,9 @@ export class Node extends EventTarget {
 
       let index = viableNextSibling
         ? mutator.indexOf(viableNextSibling)
-        : mutator.arrayInstance.length;
+        : parentNode.childNodes.length;
       let deleteNumber;
-      if (mutator.arrayInstance[index - 1] === this) {
+      if (parentNode.childNodes[index - 1] === this) {
         index--;
         deleteNumber = 1;
       } else {

--- a/src/dom/utils.ts
+++ b/src/dom/utils.ts
@@ -114,13 +114,14 @@ export function insertBeforeAfter(
   // nodes in `nodes` are removed from their parents.
   let viablePrevNextSibling: Node | null = null;
   {
+    const difference = before ? -1 : +1;
     for (
-      let i = mutator.indexOf(node) + (before ? -1 : +1);
-      0 <= i && i < mutator.arrayInstance.length;
-      before ? i-- : i++
+      let i = mutator.indexOf(node) + difference;
+      0 <= i && i < parentNode.childNodes.length;
+      i += difference
     ) {
-      if (!nodes.includes(mutator.arrayInstance[i])) {
-        viablePrevNextSibling = mutator.arrayInstance[i];
+      if (!nodes.includes(parentNode.childNodes[i])) {
+        viablePrevNextSibling = parentNode.childNodes[i];
         break;
       }
     }
@@ -131,7 +132,7 @@ export function insertBeforeAfter(
   if (viablePrevNextSibling) {
     index = mutator.indexOf(viablePrevNextSibling) + (before ? 1 : 0);
   } else {
-    index = before ? 0 : mutator.arrayInstance.length;
+    index = before ? 0 : parentNode.childNodes.length;
   }
   mutator.splice(index, 0, ...(<Node[]> nodes));
 }

--- a/test/units/Node-nodesAndTextNodes-sibllings.ts
+++ b/test/units/Node-nodesAndTextNodes-sibllings.ts
@@ -1,0 +1,76 @@
+import { DOMParser } from "../../deno-dom-wasm.ts";
+import { assertEquals } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Element.before with siblings", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div id="parent"><a></a><b></b><c></c></div>`,
+    "text/html",
+  )!;
+  const parent = doc.getElementById("parent")!;
+  const a = doc.querySelector("a")!;
+  const b = doc.querySelector("b")!;
+  const c = doc.querySelector("c")!;
+  b.before(c, a);
+  assertEquals(parent.innerHTML, "<c></c><a></a><b></b>");
+});
+
+Deno.test("Element.before with current node", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div id="parent"><a></a><b></b><c></c></div>`,
+    "text/html",
+  )!;
+  const parent = doc.getElementById("parent")!;
+  const b = doc.querySelector("b")!;
+  const c = doc.querySelector("c")!;
+  b.before(b, c);
+  assertEquals(parent.innerHTML, "<a></a><b></b><c></c>");
+});
+
+Deno.test("Element.after with siblings", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div id="parent"><a></a><b></b><c></c></div>`,
+    "text/html",
+  )!;
+  const parent = doc.getElementById("parent")!;
+  const a = doc.querySelector("a")!;
+  const b = doc.querySelector("b")!;
+  const c = doc.querySelector("c")!;
+  b.after(c, a);
+  assertEquals(parent.innerHTML, "<b></b><c></c><a></a>");
+});
+
+Deno.test("Element.after with current node", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div id="parent"><a></a><b></b><c></c></div>`,
+    "text/html",
+  )!;
+  const parent = doc.getElementById("parent")!;
+  const b = doc.querySelector("b")!;
+  const c = doc.querySelector("c")!;
+  b.after(c, b);
+  assertEquals(parent.innerHTML, "<a></a><c></c><b></b>");
+});
+
+Deno.test("Element.replaceWith with siblings", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div id="parent"><a></a><b></b><c></c></div>`,
+    "text/html",
+  )!;
+  const parent = doc.getElementById("parent")!;
+  const a = doc.querySelector("a")!;
+  const b = doc.querySelector("b")!;
+  b.replaceWith(a);
+  assertEquals(parent.innerHTML, "<a></a><c></c>");
+});
+
+Deno.test("Element.replaceWith with current node", () => {
+  const doc = new DOMParser().parseFromString(
+    `<div id="parent"><a></a><b></b><c></c></div>`,
+    "text/html",
+  )!;
+  const parent = doc.getElementById("parent")!;
+  const a = doc.querySelector("a")!;
+  const b = doc.querySelector("b")!;
+  b.replaceWith(b, a);
+  assertEquals(parent.innerHTML, "<b></b><a></a><c></c>");
+});


### PR DESCRIPTION
The `before`, `after` and `replaceWith` methods of `ChildNode` instances don't behave well when its arguments contain sibling nodes or the node on which the method is called. This is because the index on which to insert the nodes in the parent is computed before `nodesAndTextNodes` is called, which removes the passed nodes from their parents, thus invalidating the index.
