### PR TITLE
Fix #99 by adding Element.prototype.closest

### DIFF
--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -760,6 +760,21 @@ export class Element extends Node {
     return this.ownerDocument!._nwapi.match(selectorString, this);
   }
 
+  closest(selectorString: string): Element | null {
+    const { match } = this.ownerDocument!._nwapi; // See note below
+    // deno-lint-ignore no-this-alias
+    let el: Element | null = this;
+    do {
+      // Note: Not using `el.matches(selectorString)` because on a browser if you override
+      // `matches`, you *don't* see it being used by `closest`.
+      if (match(selectorString, el)) {
+        return el;
+      }
+      el = el.parentElement;
+    } while (el !== null);
+    return null;
+  }
+
   // TODO: DRY!!!
   getElementById(id: string): Element | null {
     for (const child of this.childNodes) {

--- a/test/units/Element-closest.ts
+++ b/test/units/Element-closest.ts
@@ -1,0 +1,36 @@
+import { DOMParser } from "../../deno-dom-wasm.ts";
+import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("Element-closest", () => {
+  const doc = new DOMParser().parseFromString(
+    `
+    <html class="class-a" id="a">
+      <body class="class-b" id="b">
+        <div class="class-c" id="c">
+          <div class="class-d" id="d"></div>
+        </div>
+      </body>
+    </html>
+  `,
+    "text/html",
+  )!;
+  const a = doc.getElementById("a")!;
+  const b = doc.getElementById("b")!;
+  const c = doc.getElementById("c")!;
+  const d = doc.getElementById("d")!;
+
+  // Match self
+  assert(d.closest(".class-d") === d);
+
+  // Match parent
+  assert(d.closest(".class-c") === c);
+
+  // Match grandparent
+  assert(d.closest(".class-b") === b);
+
+  // Match document element
+  assert(d.closest(".class-a") === a);
+
+  // No match
+  assert(d.closest(".class-no-match") === null);
+});


### PR DESCRIPTION
Went back and forth about whether to use `el.matches(selectorString)` or go straight to `this.ownerDocument!._nwapi.match`, but if you run this code on a browser, you *don't* see `closest` calling `matches`:

```html
<div>
  <span>
    <em id="target"></em>
  </span>
</div>
<script>
const t = document.getElementById("target");
const m = t.matches;
t.matches = function (str) {
  console.log("***************");
  return m.call(this, str);
};
console.log("closest");
console.log(t.closest(".x"));
console.log("matches");
console.log(t.matches("#target"));
</script>
```

So went with `_nwapi.match`.