### PR TITLE
fix: incorrect ts interface

### DIFF
--- a/src/dom/html-collection.ts
+++ b/src/dom/html-collection.ts
@@ -105,7 +105,7 @@ export interface HTMLCollection {
   readonly length: number;
   [Symbol.iterator](): Generator<Element>;
 
-  item(index: number): Element;
+  item(index: number): Element | null;
   [HTMLCollectionMutatorSym](): HTMLCollectionMutator;
 }
 


### PR DESCRIPTION
Creating this as a draft PR for I am sure more changes are required. But I need more understanding of the code base to verify the fix.

But the item should require an `Element | null` as the HTMLCollection specification, to ensure the types match the behaviour.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection/item#return_value

Will get back to this once I have more time.