### PR TITLE
Correct `{Node|Element}.forEach` type

### DIFF
--- a/src/dom/html-collection.ts
+++ b/src/dom/html-collection.ts
@@ -20,10 +20,9 @@ export const HTMLCollectionMutatorSym = Symbol();
 const HTMLCollectionClass: any = (() => {
   // @ts-ignore
   class HTMLCollection extends Array<Element> {
-    // @ts-ignore
     forEach(
       cb: (node: Element, index: number, nodeList: Element[]) => void,
-      thisArg: HTMLCollection | undefined = undefined,
+      thisArg?: unknown,
     ) {
       super.forEach(cb, thisArg);
     }

--- a/src/dom/node-list.ts
+++ b/src/dom/node-list.ts
@@ -118,10 +118,9 @@ class NodeListMutatorImpl {
 const NodeListClass: any = (() => {
   // @ts-ignore
   class NodeList extends Array<Node> {
-    // @ts-ignore
     forEach(
       cb: (node: Node, index: number, nodeList: Node[]) => void,
-      thisArg: NodeList | undefined = undefined,
+      thisArg?: unknown,
     ) {
       super.forEach(cb, thisArg);
     }


### PR DESCRIPTION
Fix #152