### PR TITLE
feat: support generic typing for querySelector

### DIFF
--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -307,11 +307,11 @@ export class Document extends Node {
     return doc;
   }
 
-  querySelector(selectors: string): Element | null {
-    return this._nwapi.first(selectors, this);
+  querySelector<T = Element>(selectors: string): T | null {
+    return this._nwapi.first(selectors, this) as T;
   }
 
-  querySelectorAll(selectors: string): NodeList {
+  querySelectorAll<T = Element>(selectors: string): NodeList<T> {
     const nodeList = new NodeList();
     const mutator = nodeList[nodeListMutatorSym]();
 

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -880,15 +880,15 @@ export class Element extends Node {
     return elements[index - 1] ?? null;
   }
 
-  querySelector(selectors: string): Element | null {
+  querySelector<T = Element>(selectors: string): T | null {
     if (!this.ownerDocument) {
       throw new Error("Element must have an owner document");
     }
 
-    return this.ownerDocument!._nwapi.first(selectors, this);
+    return this.ownerDocument!._nwapi.first(selectors, this) as T;
   }
 
-  querySelectorAll(selectors: string): NodeList {
+  querySelectorAll<T = Element>(selectors: string): NodeList<T> {
     if (!this.ownerDocument) {
       throw new Error("Element must have an owner document");
     }

--- a/src/dom/node-list.ts
+++ b/src/dom/node-list.ts
@@ -117,15 +117,15 @@ class NodeListMutatorImpl {
 // its prototype and completely change its TypeScript-recognized type.
 const NodeListClass: any = (() => {
   // @ts-ignore
-  class NodeList extends Array<Node> {
+  class NodeList<T = Node> extends Array<T> {
     forEach(
-      cb: (node: Node, index: number, nodeList: Node[]) => void,
+      cb: (node: T, index: number, nodeList: T[]) => void,
       thisArg?: unknown,
     ) {
       super.forEach(cb, thisArg);
     }
 
-    item(index: number): Node | null {
+    item(index: number): T | null {
       return this[index] ?? null;
     }
 
@@ -192,7 +192,7 @@ for (
   NodeListClass.prototype[instanceMethod] = undefined;
 }
 
-export interface NodeList {
+export interface NodeList<T = Node> {
   new (): NodeList;
   readonly [index: number]: Node;
   readonly length: number;

--- a/test/units/querySelector-dom-type.ts
+++ b/test/units/querySelector-dom-type.ts
@@ -8,5 +8,5 @@ Deno.test("querySelector<T> and querySelectorAll<T> typings", () => {
   )!;
 
   // We don't actually test anything here, we just challenge the TypeScript typings
-  doc.querySelector<HTMLTemplateElement>("div")!.content;
+  doc.querySelector<HTMLTemplateElement>("template")!.content;
 });

--- a/test/units/querySelector-dom-type.ts
+++ b/test/units/querySelector-dom-type.ts
@@ -1,22 +1,12 @@
-///<reference lib="dom" />
 import { DOMParser } from "../../deno-dom-wasm.ts";
+import type { HTMLTemplateElement } from "../../src/dom/elements/html-template-element.ts";
 
 Deno.test("querySelector<T> and querySelectorAll<T> typings", () => {
   const doc = new DOMParser().parseFromString(
-    `
-    <div>
-      <select>
-        <option></option>
-        <option></option>
-      </select>
-    </div>
-  `,
+    `<template></template>`,
     "text/html",
   )!;
 
   // We don't actually test anything here, we just challenge the TypeScript typings
-  const div = doc.querySelector<HTMLDivElement>("div")!;
-  const select = div.querySelector<HTMLSelectElement>("p")!;
-  select?.selectedOptions;
-  doc.querySelectorAll<HTMLOptionElement>("option")!;
+  doc.querySelector<HTMLTemplateElement>("div")!.content;
 });

--- a/test/units/querySelector-dom-type.ts
+++ b/test/units/querySelector-dom-type.ts
@@ -1,0 +1,22 @@
+///<reference lib="dom" />
+import { DOMParser } from "../../deno-dom-wasm.ts";
+
+Deno.test("querySelector<T> and querySelectorAll<T> typings", () => {
+  const doc = new DOMParser().parseFromString(
+    `
+    <div>
+      <select>
+        <option></option>
+        <option></option>
+      </select>
+    </div>
+  `,
+    "text/html",
+  )!;
+
+  // We don't actually test anything here, we just challenge the TypeScript typings
+  const div = doc.querySelector<HTMLDivElement>("div")!;
+  const select = div.querySelector<HTMLSelectElement>("p")!;
+  select?.selectedOptions;
+  doc.querySelectorAll<HTMLOptionElement>("option")!;
+});


### PR DESCRIPTION
Offer generic typing on querySelector* to simplify the usage with dom definition (https://doc.deno.land/deno/dom/)
```ts
///<reference lib="dom" />
const div = doc.querySelector<HTMLDivElement>("div")!;
```

Related #4