### PR TITLE
chore: add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+# Install deno
+ENV DENO_INSTALL=/deno
+RUN mkdir -p /deno \
+    && curl -fsSL https://deno.land/install.sh | sh \
+    && chown -R vscode /deno
+
+ENV PATH=${DENO_INSTALL}/bin:${PATH} \
+    DENO_DIR=${DENO_INSTALL}/.cache/deno

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Deno",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.defaultFormatter": "denoland.vscode-deno",
+        "deno.lint": true,
+        "deno.enable": true
+      },
+      "extensions": ["denoland.vscode-deno"]
+    },
+    "remoteUser": "vscode"
+  }
+}


### PR DESCRIPTION
This add [`devcontainer`](https://code.visualstudio.com/docs/devcontainers/create-dev-container) so contributors using vscode can have a dockerized environment with deno pre-installed