### PR TITLE
NodeList return type

### DIFF
--- a/src/dom/node-list.ts
+++ b/src/dom/node-list.ts
@@ -194,14 +194,14 @@ for (
 
 export interface NodeList<T = Node> {
   new (): NodeList;
-  readonly [index: number]: Node;
+  readonly [index: number]: T;
   readonly length: number;
-  [Symbol.iterator](): Generator<Node>;
+  [Symbol.iterator](): Generator<T>;
 
-  item(index: number): Node;
+  item(index: number): T;
   forEach(
-    cb: (node: Node, index: number, nodeList: Node[]) => void,
-    thisArg?: NodeList | undefined,
+    cb: (node: T, index: number, nodeList: T[]) => void,
+    thisArg?: NodeList<T> | undefined,
   ): void;
   [nodeListMutatorSym](): NodeListMutator;
 }


### PR DESCRIPTION
Generic param `T` was not used

- #4
- #141