### PR TITLE
Memory perf optimizations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,17 +3,17 @@ name: ci
 on:
   push:
     paths:
-      - 'Cargo.toml'
-      - 'html-parser/core/**'
-      - 'html-parser/plugin/**'
-      - '.github/workflows/**'
+      - "Cargo.toml"
+      - "html-parser/core/**"
+      - "html-parser/plugin/**"
+      - ".github/workflows/**"
   pull_request:
     branches-ignore: [master]
     paths:
-      - 'Cargo.toml'
-      - 'html-parser/core/**'
-      - 'html-parser/plugin/**'
-      - '.github/workflows/**'
+      - "Cargo.toml"
+      - "html-parser/core/**"
+      - "html-parser/plugin/**"
+      - ".github/workflows/**"
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
       - name: Install rust
         uses: hecrj/setup-rust-action@v1
         with:
-          rust-version: '1.60.0'
+          rust-version: "1.60.0"
 
       - name: Log versions
         run: |
@@ -143,7 +143,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: 'release draft'
+          tag_name: "release draft"
           draft: true
           files: |
             target/release/libplugin.dylib

--- a/README.md
+++ b/README.md
@@ -139,6 +139,37 @@ To use the new binary you need to set the **`DENO_DOM_PLUGIN`** env var to the
 path of the binary produced in the previous step. **Don't forget** to run Deno
 with `--allow-env`.
 
+## Inconsistencies with standard APIs
+
+### Differences in `DOMTokenList`/`Element.classList`
+
+To optimize memory usage, Deno DOM doesn't allocate `DOMTokenList`s
+(`Element.classList`) on `Element` creation, it instead creates an
+`UninitializedDOMTokenList` object. This can cause a subtle deviation from
+standard APIs:
+
+```typescript
+const div = doc.createElement("div");
+
+// Retrieve the uninitialized DOMTokenList
+const { classList } = div;
+
+// Initialize the DOMTokenList by adding a few classes
+classList.add("foo");
+classList.add("bar");
+
+// Inconsistency: the uninitialized classList/DOMTokenList
+// is now a different object from the initialized one
+
+classList !== div.classList;
+
+// However, the uninitialized DOMTokenList object still
+// works as the initialized DOMTokenList object:
+
+classList.add("fizz");
+div.classList.contains("fizz") === true;
+```
+
 # Credits
 
 - html5ever developers for the HTML parser

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -35,6 +35,7 @@
     "exclude": [
       "./wpt",
       "./bench/node_modules",
+      "./bench/c.html",
       "./src/dom/selectors/nwsapi.js",
       "./src/dom/selectors/sizzle.js",
       "./target",

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -56,13 +56,13 @@ function nodeFromArray(data: any, parentNode: Node | null): Node {
     switch (child[0]) {
       case NodeType.TEXT_NODE:
         childNode = new Text(child[1]);
-        childNode.parentNode = childNode.parentElement = <Element> elm;
+        childNode.parentNode = <Element> elm;
         childNodes.push(childNode);
         break;
 
       case NodeType.COMMENT_NODE:
         childNode = new Comment(child[1]);
-        childNode.parentNode = childNode.parentElement = <Element> elm;
+        childNode.parentNode = <Element> elm;
         childNodes.push(childNode);
         break;
 
@@ -73,7 +73,7 @@ function nodeFromArray(data: any, parentNode: Node | null): Node {
 
       case NodeType.DOCUMENT_TYPE_NODE:
         childNode = new DocumentType(child[1], child[2], child[3], CTOR_KEY);
-        childNode.parentNode = childNode.parentElement = <Element> elm;
+        childNode.parentNode = <Element> elm;
         childNodes.push(childNode);
         break;
     }

--- a/src/dom/document-fragment.ts
+++ b/src/dom/document-fragment.ts
@@ -137,7 +137,7 @@ function documentFragmentGetElementsByClassName(
   this: DocumentFragment,
   className: string,
 ) {
-  return getElementsByClassName(this, className, []);
+  return getElementsByClassName(this, className.trim().split(/\s+/), []);
 }
 
 function documentFragmentGetElementsByTagNameWildcard(

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -7,6 +7,7 @@ import { HTMLTemplateElement } from "./elements/html-template-element.ts";
 import { getSelectorEngine, SelectorApi } from "./selectors/selectors.ts";
 import { getElementsByClassName } from "./utils.ts";
 import UtilTypes from "./utils-types.ts";
+import { getUpperCase } from "./string-cache.ts";
 
 export class DOMImplementation {
   constructor(key: typeof CTOR_KEY) {
@@ -94,7 +95,7 @@ export class DocumentType extends Node {
     return this.#systemId;
   }
 
-  _shallowClone(): Node {
+  override _shallowClone(): Node {
     return new DocumentType(
       this.#qualifiedName,
       this.#publicId,
@@ -119,7 +120,7 @@ export class Document extends Node {
   public body: Element = <Element> <unknown> null;
   public implementation: DOMImplementation;
 
-  #lockState = false;
+  // #lockState = false;
   #documentURI = "about:blank"; // TODO
   #title = "";
   #nwapi: SelectorApi | null = null;
@@ -135,7 +136,7 @@ export class Document extends Node {
     this.implementation = new DOMImplementation(CTOR_KEY);
   }
 
-  _shallowClone(): Node {
+  override _shallowClone(): Node {
     return new Document();
   }
 
@@ -215,14 +216,14 @@ export class Document extends Node {
     return count;
   }
 
-  appendChild(child: Node): Node {
+  override appendChild(child: Node): Node {
     super.appendChild(child);
     child._setOwnerDocument(this);
     return child;
   }
 
   createElement(tagName: string, options?: ElementCreationOptions): Element {
-    tagName = tagName.toUpperCase();
+    tagName = getUpperCase(tagName);
 
     switch (tagName) {
       case "TEMPLATE": {
@@ -299,7 +300,7 @@ export class Document extends Node {
   // but that would be a breaking change since `.body`
   // and `.head` would need to be typed as `Element | null`.
   // Currently they're typed as `Element` which is incorrect...
-  cloneNode(deep?: boolean): Document {
+  override cloneNode(deep?: boolean): Document {
     const doc = super.cloneNode(deep) as Document;
 
     for (const child of doc.documentElement?.childNodes || []) {
@@ -338,6 +339,10 @@ export class Document extends Node {
 
   // TODO: DRY!!!
   getElementById(id: string): Element | null {
+    if (!this._hasInitializedChildNodes()) {
+      return null;
+    }
+
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
         if ((<Element> child).id === id) {
@@ -363,7 +368,7 @@ export class Document extends Node {
         )
         : [];
     } else {
-      return <Element[]> this._getElementsByTagName(tagName.toUpperCase(), []);
+      return <Element[]> this._getElementsByTagName(getUpperCase(tagName), []);
     }
   }
 
@@ -413,7 +418,7 @@ export class HTMLDocument extends Document {
     super();
   }
 
-  _shallowClone(): Node {
+  override _shallowClone(): Node {
     return new HTMLDocument(CTOR_KEY);
   }
 }

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -400,7 +400,11 @@ export class Document extends Node {
   }
 
   getElementsByClassName(className: string): Element[] {
-    return getElementsByClassName(this, className.trim().split(/\s+/), []) as Element[];
+    return getElementsByClassName(
+      this,
+      className.trim().split(/\s+/),
+      [],
+    ) as Element[];
   }
 
   hasFocus(): boolean {

--- a/src/dom/document.ts
+++ b/src/dom/document.ts
@@ -120,9 +120,7 @@ export class Document extends Node {
   public body: Element = <Element> <unknown> null;
   public implementation: DOMImplementation;
 
-  // #lockState = false;
   #documentURI = "about:blank"; // TODO
-  #title = "";
   #nwapi: SelectorApi | null = null;
 
   constructor() {
@@ -402,7 +400,7 @@ export class Document extends Node {
   }
 
   getElementsByClassName(className: string): Element[] {
-    return <Element[]> getElementsByClassName(this, className, []);
+    return getElementsByClassName(this, className.trim().split(/\s+/), []) as Element[];
   }
 
   hasFocus(): boolean {

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -13,12 +13,17 @@ import {
   upperCaseCharRe,
 } from "./utils.ts";
 import UtilTypes from "./utils-types.ts";
+import { getUpperCase, getLowerCase } from "./string-cache.ts";
 
 export interface DOMTokenList {
   [index: number]: string;
 }
 
 export class DOMTokenList {
+  // Minimum number of classnames/tokens in order to switch from
+  // an array-backed to a set-backed list
+  static #DOM_TOKEN_LIST_MIN_SET_SIZE = 32 as const;
+
   #_value = "";
   get #value() {
     return this.#_value;
@@ -29,7 +34,7 @@ export class DOMTokenList {
     this.#_value = value;
     this.#onChange(value);
   }
-  #set = new Set<string>();
+  #set: string[] | Set<string> = [];
   #onChange: (className: string) => void;
 
   constructor(
@@ -59,12 +64,23 @@ export class DOMTokenList {
     input: string,
   ) {
     this.#value = input;
-    this.#set = new Set(
-      input
-        .trim()
-        .split(/[\t\n\f\r\s]+/g)
-        .filter(Boolean),
-    );
+    this.#set = input
+      .trim()
+      .split(/[\t\n\f\r\s]+/g)
+      .filter(Boolean);
+
+    if (this.#set.length > DOMTokenList.#DOM_TOKEN_LIST_MIN_SET_SIZE) {
+      this.#set = new Set(this.#set);
+    } else {
+      const deduplicatedSet: string[] = [];
+      for (const element of this.#set) {
+        if (!deduplicatedSet.includes(element)) {
+          deduplicatedSet.push(element);
+        }
+      }
+      this.#set = deduplicatedSet;
+    }
+
     this.#setIndices();
   }
 
@@ -73,7 +89,11 @@ export class DOMTokenList {
   }
 
   get length(): number {
-    return this.#set.size;
+    if (this.#set.constructor === Array) {
+      return this.#set.length;
+    } else {
+      return (this.#set as Set<string>).size;
+    }
   }
 
   *entries(): IterableIterator<[number, string]> {
@@ -88,7 +108,8 @@ export class DOMTokenList {
   }
 
   *keys(): IterableIterator<number> {
-    for (let i = 0; i < this.#set.size; i++) {
+    const length = this.length;
+    for (let i = 0; i < length; i++) {
       yield i;
     }
   }
@@ -108,41 +129,73 @@ export class DOMTokenList {
   contains(
     element: string,
   ): boolean {
-    return this.#set.has(element);
+    if (this.#set.constructor === Array) {
+      return this.#set.includes(element);
+    } else {
+      return (this.#set as Set<string>).has(element);
+    }
+  }
+
+  #arrayAdd(element: string) {
+    const array = this.#set as string[];
+    if (!array.includes(element)) {
+      this[array.length] = element;
+      array.push(element);
+    }
+  }
+  #setAdd(element: string) {
+    const set = this.#set as Set<string>;
+    const { size } = set;
+    set.add(element);
+    if (size < set.size) {
+      this[size] = element;
+    }
   }
 
   add(
     ...elements: Array<string>
   ) {
+    const method = (this.#set.constructor === Array ? this.#arrayAdd : this.#setAdd).bind(this);
+
     for (const element of elements) {
       if (DOMTokenList.#invalidToken(element)) {
         throw new DOMException(
           "Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.",
         );
       }
-      const { size } = this.#set;
-      this.#set.add(element);
-      if (size < this.#set.size) {
-        this[size] = element;
-      }
+
+      method(element);
     }
     this.#updateClassString();
+  }
+
+  #arrayRemove(element: string) {
+    const array = this.#set as string[];
+    const index = array.indexOf(element);
+    if (index >= 0) {
+      array.splice(index, 1);
+    }
+  }
+  #setRemove(element: string) {
+    (this.#set as Set<string>).delete(element);
   }
 
   remove(
     ...elements: Array<string>
   ) {
-    const { size } = this.#set;
+    const method = (this.#set.constructor === Array ? this.#arrayRemove : this.#setRemove).bind(this);
+    const size = this.length;
     for (const element of elements) {
       if (DOMTokenList.#invalidToken(element)) {
         throw new DOMException(
           "Failed to execute 'remove' on 'DOMTokenList': The token provided must not be empty.",
         );
       }
-      this.#set.delete(element);
+      method(element);
     }
-    if (size !== this.#set.size) {
-      for (let i = this.#set.size; i < size; i++) {
+    const newSize = this.length;
+    if (size !== newSize) {
+      for (let i = newSize; i < size; i++) {
         delete this[i];
       }
       this.#setIndices();
@@ -154,20 +207,22 @@ export class DOMTokenList {
     oldToken: string,
     newToken: string,
   ): boolean {
+    const removeMethod = (this.#set.constructor === Array ? this.#arrayRemove : this.#setRemove).bind(this);
+    const addMethod = (this.#set.constructor === Array ? this.#arrayAdd : this.#setAdd).bind(this);
     if ([oldToken, newToken].some((v) => DOMTokenList.#invalidToken(v))) {
       throw new DOMException(
         "Failed to execute 'replace' on 'DOMTokenList': The token provided must not be empty.",
       );
     }
-    if (!this.#set.has(oldToken)) {
+    if (!this.contains(oldToken)) {
       return false;
     }
 
-    if (this.#set.has(newToken)) {
+    if (this.contains(newToken)) {
       this.remove(oldToken);
     } else {
-      this.#set.delete(oldToken);
-      this.#set.add(newToken);
+      removeMethod(oldToken);
+      addMethod(newToken);
       this.#setIndices();
       this.#updateClassString();
     }
@@ -204,8 +259,89 @@ export class DOMTokenList {
 
   #updateClassString() {
     this.#value = Array.from(this.#set).join(" ");
+
+    if (this.#set.constructor === Array && this.#set.length > DOMTokenList.#DOM_TOKEN_LIST_MIN_SET_SIZE) {
+      throw new Error("how: " + this.#set.length + " " + this.#set.join(","));
+      this.#set = new Set(this.#set);
+    }
   }
 }
+
+const initializeClassListSym = Symbol("initializeClassListSym");
+const domTokenListCurrentElementSym = Symbol("domTokenListCurrentElementSym");
+class UinitializedDOMTokenList {
+  // This will always be populated with the current element
+  // being queried
+
+  [domTokenListCurrentElementSym]: Element;
+  constructor(
+    currentElement: Element,
+  ) {
+    this[domTokenListCurrentElementSym] = currentElement;
+  }
+
+  set value(input: string) {
+    if (input?.trim?.() !== "") {
+      this[domTokenListCurrentElementSym][initializeClassListSym]();
+      this[domTokenListCurrentElementSym].classList.value = input;
+    }
+  }
+
+  get value(): string {
+    return "";
+  }
+
+  get length(): number {
+    return 0;
+  }
+
+  *entries(): IterableIterator<[number, string]> {}
+  *values(): IterableIterator<string> {}
+  *keys(): IterableIterator<number> {}
+
+  *[Symbol.iterator](): IterableIterator<string> {
+    yield* this.values();
+  }
+
+  item(_index: number): string | null {
+    return null;
+  }
+
+  contains(_element: string): boolean {
+    return false;
+  }
+
+  add(...elements: string[]) {
+    this[domTokenListCurrentElementSym][initializeClassListSym]();
+    this[domTokenListCurrentElementSym].classList.add(...elements);
+  }
+
+  remove(..._elements: string[]) {}
+  replace(_oldToken: string, _newToken: string) {
+    return false;
+  }
+
+  supports(): never {
+    throw new Error("Not implemented");
+  }
+
+  toggle(
+    element: string,
+    force?: boolean,
+  ): boolean {
+    if (force === false) {
+      return false;
+    }
+
+    this[domTokenListCurrentElementSym][initializeClassListSym]();
+    this[domTokenListCurrentElementSym].classList.add(element);
+    return true;
+  }
+
+  forEach(
+    _callback: (value: string, index: number, list: DOMTokenList) => void,
+  ) {}
+};
 
 const setNamedNodeMapOwnerElementSym = Symbol("setNamedNodeMapOwnerElementSym");
 const setAttrValueSym = Symbol("setAttrValueSym");
@@ -321,6 +457,7 @@ const getNamedNodeMapValueSym = Symbol("getNamedNodeMapValueSym");
 const getNamedNodeMapAttrNamesSym = Symbol("getNamedNodeMapAttrNamesSym");
 const getNamedNodeMapAttrNodeSym = Symbol("getNamedNodeMapAttrNodeSym");
 const removeNamedNodeMapAttrSym = Symbol("removeNamedNodeMapAttrSym");
+const getOwnerElementIdClassNameAttrOrderingSym = Symbol("getOwnerElementIdClassNameAttrOrderingSym");
 export class NamedNodeMap {
   static #indexedAttrAccess = function (
     this: NamedNodeMap,
@@ -337,11 +474,11 @@ export class NamedNodeMap {
       ?.slice(1); // Remove "a" for safeAttrName
     return this[getNamedNodeMapAttrNodeSym](attribute);
   };
-  #onAttrNodeChange: (attr: string, value: string | null) => void;
+  #onAttrNodeChange: (attr: string, value: string | null, isRemoved: boolean) => void;
 
   constructor(
     ownerElement: Element,
-    onAttrNodeChange: (attr: string, value: string | null) => void,
+    onAttrNodeChange: (attr: string, value: string | null, isRemoved: boolean) => void,
     key: typeof CTOR_KEY,
   ) {
     if (key !== CTOR_KEY) {
@@ -349,6 +486,12 @@ export class NamedNodeMap {
     }
     this.#ownerElement = ownerElement;
     this.#onAttrNodeChange = onAttrNodeChange;
+
+    // Retain ordering of any preceding id or class attributes
+    const idClassAttributeOrder = ownerElement[getOwnerElementIdClassNameAttrOrderingSym]();
+    for (const [attr] of idClassAttributeOrder) {
+      this[setNamedNodeMapValueSym](attr, ownerElement.getAttribute(attr) as string);
+    }
   }
 
   #attrNodeCache: Record<string, Attr | undefined> = {};
@@ -409,7 +552,7 @@ export class NamedNodeMap {
     this.#map[safeAttrName] = value;
 
     if (bubble) {
-      this.#onAttrNodeChange(attribute, value);
+      this.#onAttrNodeChange(attribute, value, false);
     }
   }
 
@@ -422,7 +565,7 @@ export class NamedNodeMap {
     if (this.#map[safeAttrName] !== undefined) {
       this.#length--;
       this.#map[safeAttrName] = undefined;
-      this.#onAttrNodeChange(attribute, null);
+      this.#onAttrNodeChange(attribute, null, true);
 
       const attrNode = this.#attrNodeCache[safeAttrName];
       if (attrNode) {
@@ -502,35 +645,81 @@ const xmlNamestartCharRe = new RegExp(`[${XML_NAMESTART_CHAR_RE_SRC}]`, "u");
 const xmlNameCharRe = new RegExp(`[${XML_NAME_CHAR_RE_SRC}]`, "u");
 
 export class Element extends Node {
-  localName: string;
-  attributes: NamedNodeMap = new NamedNodeMap(this, (attribute, value) => {
-    if (value === null) {
-      value = "";
+  #namedNodeMap: NamedNodeMap | null = null;
+  get attributes(): NamedNodeMap {
+    if (!this.#namedNodeMap) {
+      this.#namedNodeMap = new NamedNodeMap(this, (attribute, value, isRemoved) => {
+        if (value === null) {
+          value = "";
+        }
+
+        switch (attribute) {
+          case "class":
+            if (isRemoved) {
+              this.#hasClassNameAttribute = -1;
+            } else if (this.#hasClassNameAttribute === -1) {
+              this.#hasClassNameAttribute = this.#hasIdAttribute + 1;
+            }
+            // This must happen after the attribute is marked removed
+            this.#classList.value = value;
+          break;
+          case "id":
+            if (isRemoved) {
+              this.#hasIdAttribute = -1;
+            } else if (this.#hasIdAttribute === -1) {
+              this.#hasIdAttribute = this.#hasClassNameAttribute + 1;
+            }
+            this.#currentId = value;
+          break;
+        }
+      }, CTOR_KEY)
     }
 
-    switch (attribute) {
-      case "class":
-        this.#classList.value = value;
-        break;
-      case "id":
-        this.#currentId = value;
-        break;
-    }
-  }, CTOR_KEY);
+    return this.#namedNodeMap;
+  }
 
   #datasetProxy: Record<string, string | undefined> | null = null;
   #currentId = "";
-  #classList = new DOMTokenList(
-    (className) => {
-      if (this.hasAttribute("class") || className !== "") {
-        this.attributes[setNamedNodeMapValueSym]("class", className);
-      }
-    },
-    CTOR_KEY,
-  );
+  #currentClassName = "";
+  #hasIdAttribute = -1;
+  #hasClassNameAttribute = -1;
+
+  /**
+   * Used when a NamedNodeMap is initialized so that it can persist the id and
+   * class attributes with the correct ordering
+   */
+  [getOwnerElementIdClassNameAttrOrderingSym](): Array<[string, number]> {
+    const unordered: Array<[string, number]> = [
+      ["id", this.#hasIdAttribute],
+      ["class", this.#hasClassNameAttribute],
+    ];
+    return unordered
+      .filter(([_attr, order]) => Boolean(~order))
+      .sort(([_a, orderA], [_b, orderB]) => orderA - orderB);
+  }
+
+  // Only initialize a classList when we need one
+  #classListInstance: DOMTokenList | null = null;
+  #uninitializedClassListInstance: UinitializedDOMTokenList | null = new UinitializedDOMTokenList(this);
+  get #classList(): DOMTokenList {
+    return this.#classListInstance || this.#uninitializedClassListInstance as unknown as DOMTokenList;
+  }
+
+  [initializeClassListSym]() {
+    this.#uninitializedClassListInstance = null;
+    this.#classListInstance = new DOMTokenList(
+      (className) => {
+        this.#currentClassName = className;
+        if (this.#namedNodeMap && (this.hasAttribute("class") || className !== "")) {
+          this.attributes[setNamedNodeMapValueSym]("class", className);
+        }
+      },
+      CTOR_KEY,
+    );
+  }
 
   constructor(
-    public tagName: string,
+    tagName: string,
     parentNode: Node | null,
     attributes: [string, string][],
     key: typeof CTOR_KEY,
@@ -544,22 +733,20 @@ export class Element extends Node {
 
     for (const attr of attributes) {
       this.setAttribute(attr[0], attr[1]);
-
-      switch (attr[0]) {
-        case "class":
-          this.#classList.value = attr[1];
-          break;
-        case "id":
-          this.#currentId = attr[1];
-          break;
-      }
     }
 
-    this.tagName = this.nodeName = tagName.toUpperCase();
-    this.localName = tagName.toLowerCase();
+    this.nodeName = getUpperCase(tagName);
   }
 
-  _shallowClone(): Node {
+  get tagName(): string {
+    return this.nodeName;
+  }
+
+  get localName(): string {
+    return getLowerCase(this.tagName);
+  }
+
+  override _shallowClone(): Node {
     // FIXME: This attribute copying needs to also be fixed in other
     // elements that override _shallowClone like <template>
     const attributes: [string, string][] = [];
@@ -574,11 +761,10 @@ export class Element extends Node {
   }
 
   get className(): string {
-    return this.getAttribute("class") ?? "";
+    return this.#currentClassName;
   }
 
   set className(className: string) {
-    this.setAttribute("class", className);
     this.#classList.value = className;
   }
 
@@ -672,7 +858,7 @@ export class Element extends Node {
   }
 
   set id(id: string) {
-    this.setAttribute("id", this.#currentId = id);
+    this.setAttribute("id", id);
   }
 
   get dataset(): Record<string, string | undefined> {
@@ -773,36 +959,93 @@ export class Element extends Node {
   }
 
   getAttributeNames(): string[] {
+    if (!this.#namedNodeMap) {
+      const attributes = [];
+      ~this.#hasIdAttribute && attributes.push("id");
+      ~this.#hasClassNameAttribute && attributes.push("class");
+      return attributes;
+    }
+
     return this.attributes[getNamedNodeMapAttrNamesSym]();
   }
 
-  getAttribute(name: string): string | null {
-    return this.attributes[getNamedNodeMapValueSym](name.toLowerCase()) ?? null;
+  getAttribute(rawName: string): string | null {
+    const name = getLowerCase(String(rawName));
+
+    switch (name) {
+      case "id": {
+        if (~this.#hasIdAttribute) {
+          return this.#currentId;
+        } else {
+          return null;
+        }
+      }
+      case "class": {
+        if (~this.#hasClassNameAttribute) {
+          return this.#currentClassName;
+        } else {
+          return null;
+        }
+      }
+    }
+
+    if (!this.#namedNodeMap) {
+      return null;
+    }
+
+    return this.attributes[getNamedNodeMapValueSym](name) ?? null;
   }
 
   setAttribute(rawName: string, value: any) {
-    const name = String(rawName?.toLowerCase());
+    const name = getLowerCase(String(rawName));
     const strValue = String(value);
-    this.attributes[setNamedNodeMapValueSym](name, strValue);
+    let isNormalAttribute = false;
 
-    if (name === "id") {
-      this.#currentId = strValue;
-    } else if (name === "class") {
-      this.#classList.value = strValue;
+    switch (name) {
+      case "id": {
+        this.#currentId = strValue;
+        this.#hasIdAttribute = this.#hasClassNameAttribute + 1;
+        break;
+      }
+      case "class": {
+        this.#classList.value = strValue;
+        this.#hasClassNameAttribute = this.#hasIdAttribute + 1;
+        break;
+      }
+      default: {
+        isNormalAttribute = true;
+      }
+    }
+
+    if (this.#namedNodeMap || isNormalAttribute) {
+      this.attributes[setNamedNodeMapValueSym](name, strValue);
     }
   }
 
   removeAttribute(rawName: string) {
-    const name = String(rawName?.toLowerCase());
-    this.attributes[removeNamedNodeMapAttrSym](name);
-
-    if (name === "class") {
-      this.#classList.value = "";
+    const name = getLowerCase(String(rawName));
+    switch (name) {
+      case "id": {
+        this.#currentId = "";
+        this.#hasIdAttribute = -1;
+        break;
+      }
+      case "class": {
+        this.#classList.value = "";
+        this.#hasClassNameAttribute = -1;
+        break;
+      }
     }
+
+    if (!this.#namedNodeMap) {
+      return;
+    }
+
+    this.attributes[removeNamedNodeMapAttrSym](name);
   }
 
   toggleAttribute(rawName: string, force?: boolean): boolean {
-    const name = String(rawName?.toLowerCase());
+    const name = getLowerCase(String(rawName));
     if (this.hasAttribute(name)) {
       if ((force === undefined) || (force === false)) {
         this.removeAttribute(name);
@@ -817,17 +1060,43 @@ export class Element extends Node {
     return false;
   }
 
-  hasAttribute(name: string): boolean {
-    return this.attributes[getNamedNodeMapValueSym](
-      String(name?.toLowerCase()),
-    ) !== undefined;
+  hasAttribute(rawName: string): boolean {
+    const name = getLowerCase(String(rawName));
+
+    switch (name) {
+      case "id": {
+        return Boolean(~this.#hasIdAttribute);
+      }
+      case "class": {
+        return Boolean(~this.#hasClassNameAttribute);
+      }
+    }
+
+    if (!this.#namedNodeMap) {
+      return false;
+    }
+
+    return this.attributes[getNamedNodeMapValueSym](name) !== undefined;
   }
 
-  hasAttributeNS(_namespace: string, name: string): boolean {
+  hasAttributeNS(_namespace: string, rawName: string): boolean {
+    const name = getLowerCase(String(rawName));
+
+    switch (name) {
+      case "id": {
+        return Boolean(~this.#hasIdAttribute);
+      }
+      case "class": {
+        return Boolean(~this.#hasClassNameAttribute);
+      }
+    }
+
+    if (!this.#namedNodeMap) {
+      return false;
+    }
+
     // TODO: Use namespace
-    return this.attributes[getNamedNodeMapValueSym](
-      String(name?.toLowerCase()),
-    ) !== undefined;
+    return this.attributes[getNamedNodeMapValueSym](name) !== undefined;
   }
 
   replaceWith(...nodes: (Node | string)[]) {
@@ -942,6 +1211,10 @@ export class Element extends Node {
 
   // TODO: DRY!!!
   getElementById(id: string): Element | null {
+    if (!this._hasInitializedChildNodes()) {
+      return null;
+    }
+
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
         if ((<Element> child).id === id) {
@@ -959,16 +1232,20 @@ export class Element extends Node {
   }
 
   getElementsByTagName(tagName: string): Element[] {
-    const fixCaseTagName = tagName.toUpperCase();
+    const fixCaseTagName = getUpperCase(tagName);
 
     if (fixCaseTagName === "*") {
       return <Element[]> this._getElementsByTagNameWildcard([]);
     } else {
-      return <Element[]> this._getElementsByTagName(tagName.toUpperCase(), []);
+      return <Element[]> this._getElementsByTagName(fixCaseTagName, []);
     }
   }
 
   _getElementsByTagNameWildcard(search: Node[]): Node[] {
+    if (!this._hasInitializedChildNodes()) {
+      return search;
+    }
+
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
         search.push(child);
@@ -980,6 +1257,10 @@ export class Element extends Node {
   }
 
   _getElementsByTagName(tagName: string, search: Node[]): Node[] {
+    if (!this._hasInitializedChildNodes()) {
+      return search;
+    }
+
     for (const child of this.childNodes) {
       if (child.nodeType === NodeType.ELEMENT_NODE) {
         if ((<Element> child).tagName === tagName) {

--- a/src/dom/element.ts
+++ b/src/dom/element.ts
@@ -13,7 +13,7 @@ import {
   upperCaseCharRe,
 } from "./utils.ts";
 import UtilTypes from "./utils-types.ts";
-import { getUpperCase, getLowerCase } from "./string-cache.ts";
+import { getLowerCase, getUpperCase } from "./string-cache.ts";
 
 export interface DOMTokenList {
   [index: number]: string;
@@ -155,7 +155,10 @@ export class DOMTokenList {
   add(
     ...elements: Array<string>
   ) {
-    const method = (this.#set.constructor === Array ? this.#arrayAdd : this.#setAdd).bind(this);
+    const method =
+      (this.#set.constructor === Array ? this.#arrayAdd : this.#setAdd).bind(
+        this,
+      );
 
     for (const element of elements) {
       if (DOMTokenList.#invalidToken(element)) {
@@ -183,7 +186,9 @@ export class DOMTokenList {
   remove(
     ...elements: Array<string>
   ) {
-    const method = (this.#set.constructor === Array ? this.#arrayRemove : this.#setRemove).bind(this);
+    const method =
+      (this.#set.constructor === Array ? this.#arrayRemove : this.#setRemove)
+        .bind(this);
     const size = this.length;
     for (const element of elements) {
       if (DOMTokenList.#invalidToken(element)) {
@@ -208,8 +213,11 @@ export class DOMTokenList {
     newToken: string,
   ): boolean {
     const isArrayBacked = this.#set.constructor === Array;
-    const removeMethod = (isArrayBacked ? this.#arrayRemove : this.#setRemove).bind(this);
-    const addMethod = (isArrayBacked ? this.#arrayAdd : this.#setAdd).bind(this);
+    const removeMethod = (isArrayBacked ? this.#arrayRemove : this.#setRemove)
+      .bind(this);
+    const addMethod = (isArrayBacked ? this.#arrayAdd : this.#setAdd).bind(
+      this,
+    );
     if ([oldToken, newToken].some((v) => DOMTokenList.#invalidToken(v))) {
       throw new DOMException(
         "Failed to execute 'replace' on 'DOMTokenList': The token provided must not be empty.",
@@ -261,7 +269,10 @@ export class DOMTokenList {
   #updateClassString() {
     this.#value = Array.from(this.#set).join(" ");
 
-    if (this.#set.constructor === Array && this.#set.length > DOMTokenList.#DOM_TOKEN_LIST_MIN_SET_SIZE) {
+    if (
+      this.#set.constructor === Array &&
+      this.#set.length > DOMTokenList.#DOM_TOKEN_LIST_MIN_SET_SIZE
+    ) {
       this.#set = new Set(this.#set);
     }
   }
@@ -520,7 +531,10 @@ export class NamedNodeMap {
 
     // Retain ordering of any preceding id or class attributes
     for (const attr of ownerElement.getAttributeNames()) {
-      this[setNamedNodeMapValueSym](attr, ownerElement.getAttribute(attr) as string);
+      this[setNamedNodeMapValueSym](
+        attr,
+        ownerElement.getAttribute(attr) as string,
+      );
     }
   }
 
@@ -706,7 +720,7 @@ export class Element extends Node {
             break;
           }
         }
-      }, CTOR_KEY)
+      }, CTOR_KEY);
     }
 
     return this.#namedNodeMap;
@@ -719,7 +733,9 @@ export class Element extends Node {
   #hasClassNameAttribute = -1;
 
   // Only initialize a classList when we need one
-  #classListInstance: DOMTokenList = new UninitializedDOMTokenList(this) as unknown as DOMTokenList;
+  #classListInstance: DOMTokenList = new UninitializedDOMTokenList(
+    this,
+  ) as unknown as DOMTokenList;
   get #classList(): DOMTokenList {
     return this.#classListInstance;
   }
@@ -736,7 +752,10 @@ export class Element extends Node {
           if (this.#hasClassNameAttribute === -1) {
             this.#hasClassNameAttribute = this.#hasIdAttribute + 1;
           }
-          if (this.#namedNodeMap && (this.hasAttribute("class") || className !== "")) {
+          if (
+            this.#namedNodeMap &&
+            (this.hasAttribute("class") || className !== "")
+          ) {
             this.attributes[setNamedNodeMapValueSym]("class", className);
           }
         }
@@ -991,7 +1010,9 @@ export class Element extends Node {
 
       // We preserve the order of the "id" and "class" attributes when
       // returning the list of names with an uninitialized NamedNodeMap
-      const startWithClassAttr = Number(this.#hasIdAttribute > this.#hasClassNameAttribute);
+      const startWithClassAttr = Number(
+        this.#hasIdAttribute > this.#hasClassNameAttribute,
+      );
       for (let i = 0; i < 2; i++) {
         const attributeIdx = (i + startWithClassAttr) % 2;
         switch (attributeIdx) {
@@ -1332,7 +1353,11 @@ export class Element extends Node {
       return [];
     }
 
-    return getElementsByClassName(this, className.trim().split(/\s+/), []) as Element[];
+    return getElementsByClassName(
+      this,
+      className.trim().split(/\s+/),
+      [],
+    ) as Element[];
   }
 
   getElementsByTagNameNS(_namespace: string, localName: string): Element[] {

--- a/src/dom/elements/html-template-element.ts
+++ b/src/dom/elements/html-template-element.ts
@@ -71,12 +71,12 @@ export class HTMLTemplateElement extends Element {
     return newNode;
   }
 
-  get innerHTML(): string {
+  override get innerHTML(): string {
     return getOuterOrInnerHtml(this, false);
   }
 
   // Replace children in the `.content`
-  set innerHTML(html: string) {
+  override set innerHTML(html: string) {
     const content = this.content;
 
     // Remove all children
@@ -99,7 +99,7 @@ export class HTMLTemplateElement extends Element {
     }
   }
 
-  get outerHTML(): string {
+  override get outerHTML(): string {
     return `<template${
       getElementAttributesString(this)
     }>${this.innerHTML}</template>`;

--- a/src/dom/html-collection.ts
+++ b/src/dom/html-collection.ts
@@ -20,7 +20,7 @@ export const HTMLCollectionMutatorSym = Symbol("HTMLCollectionMutatorSym");
 const HTMLCollectionClass: any = (() => {
   // @ts-ignore
   class HTMLCollection extends Array<Element> {
-    forEach(
+    override forEach(
       cb: (node: Element, index: number, nodeList: Element[]) => void,
       thisArg?: unknown,
     ) {
@@ -41,7 +41,7 @@ const HTMLCollectionClass: any = (() => {
       };
     }
 
-    toString() {
+    override toString() {
       return "[object HTMLCollection]";
     }
   }

--- a/src/dom/node-list.ts
+++ b/src/dom/node-list.ts
@@ -118,7 +118,7 @@ class NodeListMutatorImpl {
 const NodeListClass: any = (() => {
   // @ts-ignore
   class NodeList<T = Node> extends Array<T> {
-    forEach(
+    override forEach(
       cb: (node: T, index: number, nodeList: T[]) => void,
       thisArg?: unknown,
     ) {
@@ -141,7 +141,7 @@ const NodeListClass: any = (() => {
       }
     }
 
-    toString() {
+    override toString() {
       return "[object NodeList]";
     }
   }

--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -38,7 +38,7 @@ export function nodesAndTextNodes(
       moveDocumentFragmentChildren(n as DocumentFragment, parentNode);
       return children;
     } else {
-      const node: Node = n instanceof Node ? n : new Text("" + n);
+      const node: Node = n instanceof Node ? n : new Text(String(n));
 
       // Make sure the node isn't an ancestor of parentNode
       if (n === node && parentNode) {
@@ -59,7 +59,6 @@ export class Node extends EventTarget {
   #nodeValue: string | null = null;
   public parentNode: Node | null = null;
   #ownerDocument: Document | null = null;
-  private _ancestors: Set<Node> | null = null;
 
   get parentElement(): Element | null {
     if (this.parentNode?.nodeType === NodeType.ELEMENT_NODE) {
@@ -130,16 +129,6 @@ export class Node extends EventTarget {
         if (!sameParent) {
           this._setOwnerDocument(newParent.#ownerDocument);
         }
-
-        // Add parent chain to ancestors
-        if (this.nodeType !== NodeType.TEXT_NODE) {
-          // this._ancestors = new Set(newParent._ancestors);
-          // this._ancestors.add(newParent);
-        }
-      } else {
-        if (this._ancestors) {
-          this._ancestors.clear();
-        }
       }
 
       // Update ancestors for child nodes
@@ -171,17 +160,16 @@ export class Node extends EventTarget {
   }
 
   contains(child: Node): boolean {
-    return false;
-    // if (!child._ancestors) {
-    //   if (child.parentNode) {
-    //     child._ancestors = new Set(child.parentNode._ancestors);
-    //     child._ancestors.add(child.parentNode);
-    //   } else {
-    //     child._ancestors = new Set();
-    //   }
-    // }
+    let node: Node | null = child;
+    while (node) {
+      if (node === this) {
+        return true;
+      }
 
-    // return child._ancestors.has(this) || child === this;
+      node = node.parentNode;
+    }
+
+    return false;
   }
 
   get ownerDocument(): Document | null {

--- a/src/dom/string-cache.ts
+++ b/src/dom/string-cache.ts
@@ -1,0 +1,12 @@
+const upperCasedStringCache: Map<string, string> = new Map();
+const lowerCasedStringCache: Map<string, string> = new Map();
+
+export function getUpperCase(string: string): string {
+  return upperCasedStringCache.get(string)
+    ?? upperCasedStringCache.set(string, string.toUpperCase()).get(string)!;
+}
+
+export function getLowerCase(string: string): string {
+  return lowerCasedStringCache.get(string)
+    ?? lowerCasedStringCache.set(string, string.toLowerCase()).get(string)!;
+}

--- a/src/dom/string-cache.ts
+++ b/src/dom/string-cache.ts
@@ -2,11 +2,11 @@ const upperCasedStringCache: Map<string, string> = new Map();
 const lowerCasedStringCache: Map<string, string> = new Map();
 
 export function getUpperCase(string: string): string {
-  return upperCasedStringCache.get(string)
-    ?? upperCasedStringCache.set(string, string.toUpperCase()).get(string)!;
+  return upperCasedStringCache.get(string) ??
+    upperCasedStringCache.set(string, string.toUpperCase()).get(string)!;
 }
 
 export function getLowerCase(string: string): string {
-  return lowerCasedStringCache.get(string)
-    ?? lowerCasedStringCache.set(string, string.toLowerCase()).get(string)!;
+  return lowerCasedStringCache.get(string) ??
+    lowerCasedStringCache.set(string, string.toLowerCase()).get(string)!;
 }

--- a/src/dom/utils.ts
+++ b/src/dom/utils.ts
@@ -1,6 +1,7 @@
 import { Comment, Node, nodesAndTextNodes, NodeType, Text } from "./node.ts";
 import { NodeList } from "./node-list.ts";
 import UtilTypes from "./utils-types.ts";
+import { getLowerCase } from "./string-cache.ts";
 import type { Element } from "./element.ts";
 import type { HTMLTemplateElement } from "./elements/html-template-element.ts";
 import type { DocumentFragment } from "./document-fragment.ts";
@@ -190,15 +191,13 @@ export function getOuterOrInnerHtml(
   return outerHTMLOpeningTag + innerHTML;
 }
 
-// FIXME: This uses the incorrect .attributes implementation, it
-// should probably be changed when .attributes is fixed
 export function getElementAttributesString(
   element: Element,
 ): string {
   let out = "";
 
   for (const attribute of element.getAttributeNames()) {
-    out += ` ${attribute.toLowerCase()}`;
+    out += ` ${getLowerCase(attribute)}`;
 
     // escaping: https://html.spec.whatwg.org/multipage/parsing.html#escapingString
     out += `="${

--- a/src/dom/utils.ts
+++ b/src/dom/utils.ts
@@ -43,26 +43,25 @@ export function getDatasetJavascriptName(name: string): string {
 
 export function getElementsByClassName(
   element: any,
-  className: string,
+  classNames: string[],
   search: Node[],
 ): Node[] {
   for (const child of element.childNodes) {
     if (child.nodeType === NodeType.ELEMENT_NODE) {
-      const classList = className.trim().split(/\s+/);
       let matchesCount = 0;
 
-      for (const singleClassName of classList) {
-        if ((<Element> child).classList.contains(singleClassName)) {
+      for (const singleClassName of classNames) {
+        if ((child as Element).classList.contains(singleClassName)) {
           matchesCount++;
         }
       }
 
       // ensure that all class names are present
-      if (matchesCount === classList.length) {
+      if (matchesCount === classNames.length) {
         search.push(child);
       }
 
-      getElementsByClassName(<Element> child, className, search);
+      getElementsByClassName(child as Element, classNames, search);
     }
   }
 
@@ -197,7 +196,8 @@ export function getElementAttributesString(
   let out = "";
 
   for (const attribute of element.getAttributeNames()) {
-    out += ` ${getLowerCase(attribute)}`;
+    // attribute names should already all be lower-case
+    out += ` ${attribute}`;
 
     // escaping: https://html.spec.whatwg.org/multipage/parsing.html#escapingString
     out += `="${

--- a/test/units/Element-classList.ts
+++ b/test/units/Element-classList.ts
@@ -8,10 +8,12 @@ import {
 
 Deno.test("Element.classList.value", () => {
   const doc = new DOMParser().parseFromString(
-    "<div class='a b'></div>",
+    "<div class='a b'></div><main></main>",
     "text/html",
   );
   const div = doc.querySelector("div")!;
+  const main = doc.querySelector("main")!;
+  main.classList.value = "a b";
   assertStrictEquals(
     div.classList.value,
     "a b",
@@ -53,6 +55,11 @@ Deno.test("Element.classList.value", () => {
     "c d e",
     `div.classList.value should be "c d e", got "${div.classList.value}"`,
   );
+  assertStrictEquals(
+    main.getAttribute("class"),
+    "a b",
+    "main.classList.value = ... should set the 'class' attribute",
+  );
 });
 
 Deno.test("Element.classList.length", () => {
@@ -89,7 +96,7 @@ Deno.test("Element.classList.length", () => {
 });
 
 Deno.test("Element.classList.add", () => {
-  const doc = new DOMParser().parseFromString("<div></div>", "text/html");
+  const doc = new DOMParser().parseFromString("<div></div><main></main>", "text/html");
   const div = doc.querySelector("div")!;
   div.classList.add("a");
   div.classList.add("b", "c");
@@ -116,6 +123,11 @@ Deno.test("Element.classList.add", () => {
     DOMException,
     "The token provided must not be empty",
     "DOMTokenList.add() shouldn't accept an empty string.",
+  );
+  assertStrictEquals(
+    div.getAttribute("class"),
+    "a b c",
+    "div.classList.add(...) should set the 'class' attribute",
   );
 });
 

--- a/test/units/Element-classList.ts
+++ b/test/units/Element-classList.ts
@@ -96,7 +96,10 @@ Deno.test("Element.classList.length", () => {
 });
 
 Deno.test("Element.classList.add", () => {
-  const doc = new DOMParser().parseFromString("<div></div><main></main>", "text/html");
+  const doc = new DOMParser().parseFromString(
+    "<div></div><main></main>",
+    "text/html",
+  );
   const div = doc.querySelector("div")!;
   div.classList.add("a");
   div.classList.add("b", "c");

--- a/test/units/NamedNodeMap.ts
+++ b/test/units/NamedNodeMap.ts
@@ -269,7 +269,11 @@ Deno.test("Uninitialized NamedNodeMap preserves ID and className attribute order
   assertDeepEquals(div3.getAttributeNames(), ["id"]);
   assertDeepEquals(div4.getAttributeNames(), ["class"]);
   assertDeepEquals(div5.getAttributeNames(), ["data-others", "class", "id"]);
-  assertDeepEquals(div6.getAttributeNames(), ["id", "data-more-others", "class"]);
+  assertDeepEquals(div6.getAttributeNames(), [
+    "id",
+    "data-more-others",
+    "class",
+  ]);
 
   // Test that ordering is undisturbed when setting id/class a second time
   div1.setAttribute("id", "div1-id");

--- a/test/units/basic.html
+++ b/test/units/basic.html
@@ -11,4 +11,3 @@
     <a>He was sure to go</a>
   </body>
 </html>
-

--- a/test/units/cloneNode.ts
+++ b/test/units/cloneNode.ts
@@ -33,9 +33,18 @@ Deno.test("cloneNode works with uninitialized NamedNodeMap", () => {
   const div2 = doc.querySelector("#baz")!;
   const div3 = doc.querySelector("#fizz")!;
 
-  assertEquals(div1.getAttributeNames(), (div1.cloneNode() as Element).getAttributeNames());
-  assertEquals(div2.getAttributeNames(), (div2.cloneNode() as Element).getAttributeNames());
-  assertEquals(div3.getAttributeNames(), (div3.cloneNode() as Element).getAttributeNames());
+  assertEquals(
+    div1.getAttributeNames(),
+    (div1.cloneNode() as Element).getAttributeNames(),
+  );
+  assertEquals(
+    div2.getAttributeNames(),
+    (div2.cloneNode() as Element).getAttributeNames(),
+  );
+  assertEquals(
+    div3.getAttributeNames(),
+    (div3.cloneNode() as Element).getAttributeNames(),
+  );
 });
 
 function checkClone(node: Node, clone: Node) {

--- a/test/units/cloneNode.ts
+++ b/test/units/cloneNode.ts
@@ -2,22 +2,40 @@ import { DOMParser, Element, Node } from "../../deno-dom-wasm.ts";
 import {
   assert,
   assertEquals,
-  assertNotEquals,
 } from "https://deno.land/std@0.85.0/testing/asserts.ts";
 
 Deno.test("cloneNode", () => {
   const doc = new DOMParser().parseFromString(
     `
-    a
-    <p>b</p>
-    <ul><li>c</li></ul>
-    <!-- d -->
-    <a id="e">e</a>
-  `,
+      a
+      <p>b</p>
+      <ul><li>c</li></ul>
+      <!-- d -->
+      <a id="e">e</a>
+    `,
     "text/html",
   );
 
   checkClone(doc, doc.cloneNode(true));
+});
+
+Deno.test("cloneNode works with uninitialized NamedNodeMap", () => {
+  const doc = new DOMParser().parseFromString(
+    `
+      <div class=foo id=bar></div>
+      <div id=baz class=qux></div>
+      <div id=fizz data-foo class=some-class></div>
+    `,
+    "text/html",
+  );
+
+  const div1 = doc.querySelector("#bar")!;
+  const div2 = doc.querySelector("#baz")!;
+  const div3 = doc.querySelector("#fizz")!;
+
+  assertEquals(div1.getAttributeNames(), (div1.cloneNode() as Element).getAttributeNames());
+  assertEquals(div2.getAttributeNames(), (div2.cloneNode() as Element).getAttributeNames());
+  assertEquals(div3.getAttributeNames(), (div3.cloneNode() as Element).getAttributeNames());
 });
 
 function checkClone(node: Node, clone: Node) {


### PR DESCRIPTION
Measuring the full Deno docs build we can see the following improvements in memory usage:

**Before:**
- 11GiB RAM
- 3 minutes 29 seconds total time

**After:**
- 6.8GiB RAM
- 1 minutes 30 seconds total time

Memory is taken from `Deno.memoryUsage()`